### PR TITLE
Unified light clients name (thin mostly replaced to light)

### DIFF
--- a/src/architecture/services.md
+++ b/src/architecture/services.md
@@ -63,7 +63,7 @@ middleware layer.
 ### Transactions
 
 Transactions come from the entities external to the blockchain, e.g.,
-[thin clients](clients.md). Generally speaking, a transaction modifies the blockchain
+[light clients](clients.md). Generally speaking, a transaction modifies the blockchain
 state if the transaction is considered “correct”. All transactions are recorded
 in the blockchain as a part of the transaction log. As the name implies,
 transactions are [atomic][wiki:atomicity]; they are deterministically ordered
@@ -93,7 +93,7 @@ received the request.
 
 One of distinguishing features of the Exonum framework is that it provides
 a rich set of tools to bundle responses to reads with cryptographic proofs.
-Proofs allow thin clients
+Proofs allow light clients
 to minimize their trust to the responding node. Essentially, a retrieved response
 is as secure as if the client queried a supermajority of blockchain validators.
 
@@ -101,7 +101,7 @@ is as secure as if the client queried a supermajority of blockchain validators.
     In cryptographic terms, a proof opens a [commitment][wiki:crypto-commit]
     to data in the blockchain, where the commitment is stored in a block header
     in the form of a state hash. The use of Merkle trees and Merkle Patricia trees
-    allows to make proofs compact enough to be processed by thin clients.
+    allows to make proofs compact enough to be processed by light clients.
 
 !!! note "Example"
     Retrieving information on a particular wallet (e.g., the current
@@ -145,7 +145,7 @@ the items of the collection. Merklized versions of maps and lists are
 Naturally, the items of collections (and keys in the case of maps) need to be
 serializable. Exonum provides a simple and robust [binary serialization format](serialization.md),
 and the corresponding set of tools for (de)serialization and conversion of
-Exonum datatypes to JSON for communication with thin clients.
+Exonum datatypes to JSON for communication with light clients.
 
 ### Configuration
 
@@ -224,7 +224,7 @@ blockchain network
 !!! note
     As of Exonum 0.1, the only built-in event is block commit. More events
     will be added in the future, including possibility for services to define
-    and emit events and for services and thin clients to subscribe to events
+    and emit events and for services and light clients to subscribe to events
     emitted by the services.
 
 ## Service Development

--- a/src/get-started/what-is-exonum.md
+++ b/src/get-started/what-is-exonum.md
@@ -171,12 +171,12 @@ The Exonum network would continue operating even if up to 1/3 validators are hac
 compromised or switched off. Hence, there is no single point of failure
 in the network; the whole process of transaction processing is fully decentralized.
 
-### Thin Clients
+### Light Clients
 
-Exonum supports [thin clients](../architecture/clients.md),
+Exonum supports [light clients](../architecture/clients.md),
 network nodes that replicate only a very small part of the blockchain,
-which the client is interested in. Thin clients allow to provide access to blockchain
-through web or mobile apps. A thin client communicates with one or
+which the client is interested in. Light clients allow to provide access to blockchain
+through web or mobile apps. A light client communicates with one or
 more services on a full node with the help of [public APIs](#endpoints).
 
 !!! note "Example"
@@ -184,7 +184,7 @@ more services on a full node with the help of [public APIs](#endpoints).
     a client corresponds to an owner of currency; it is only interested in transactions
     that involve the owner.
 
-Exonum pays much attention to the security of thin clients. Thin clients do not
+Exonum pays much attention to the security of light clients. Light clients do not
 unconditionally trust the responses from full nodes, but rather verify them
 against formally encoded rules. The verification uses cryptographic techniques,
 such as [Merkle trees][wiki:mt] and [linked timestamping][wiki:linked-ts],
@@ -194,13 +194,13 @@ among the blockchain maintainers.
 ### Bitcoin Anchoring
 
 Exonum provides [an anchoring service](../advanced/bitcoin-anchoring.md)
-to achieve the most complete security for thin clients. The anchoring service
+to achieve the most complete security for light clients. The anchoring service
 periodically publishes a hash digest of the entire blockchain state
 to the Bitcoin Blockchain. This makes it impossible to revise the transaction
 history or to supply different clients with differing versions of the blockchain,
 even if all the blockchain maintainers collude. Moreover, anchoring is a fallback
 mechanism: even if the Exonum blockchain stops working, the authenticity of data
-stored in thin clients could still be verified.
+stored in light clients could still be verified.
 
 ## What’s Next
 


### PR DESCRIPTION
Unified clients spelling to `light clients` (though `thin clients` is left as alias)