### PR TITLE
WIP: Redirect build notifications to gitter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,6 @@ after_script:
   - bash ./misc/lint.sh kill
 
 notifications:
-  slack:
-    rooms:
-      secure: m+EwYesnSFJxJbwPI890FiXlWl/EaqKYNMDNE/Ti4vlsFTNQOHuYFdj6vihaGn53E3+aWaRnQ9jFJNXFyPab+LyeYErGssuhuN+QFVAGvACXtl54zYspNIx+zk6gN5mjX9vsP15K/XJi+YTX25zk9lyN6WlMdPvoW9cQqpMLxYyCG92aVfpHdsax3iocDWpQQBv0G1CWHGTyz2bcwFGQLcU4zQArwuM5iNtBWI7GOZFhtiXKCPLWFi22wSnMEsusUNygS/co98bNG8N54Y+BCos8/s302ygyOOPHlXEGQOsUaCo7MHTxL5rF+LNUrKkf/VhH7sSDI6y4gpgtQAnDNvQ0kjNs8UuWnRA928HNEAMvyNTrZX/ArUoDVldYhYDjVrbzUO/CIJMSy2CYTMQLA46/WzyR/tmlLpX7A1Xu3KC5SSGbPxnuzTg+anonOrJZNW3B9tF4CK6wX7w18xY6iSVN0WdvEOUXLAOfhnRgUn4S8Hx6/bl8jME9is5mqMRAkvY4moYXL2ZV0LkRshyJKLBTuGLYhqm9nqZcyDzg3gf1BfFEWlY5NZlrHnDyl5UuQRmoHIrr55FU9SJp4TEf+11UY0G9ZEy8q9CSp4YKe1YJ+AkzKcx1LPSwoIaq4wpPpj0KWlXqJiY4Jw4kO1XuywXewre6Yk0CiIR9XvBHxHs=
+  webhooks:
+    urls:
+      - https://webhooks.gitter.im/e/1e308aa352e6383b3e01


### PR DESCRIPTION
This PR switches build notifications from Slack to [gitter](https://gitter.im/exonum/exonum-doc).

Shouldn't be merged until we actively start using gitter (after publishing?).