### PR TITLE
Wrong command line option for version

### DIFF
--- a/src/get-started/install.md
+++ b/src/get-started/install.md
@@ -98,7 +98,7 @@ of `rustfmt` in order to get consistent formatting.
 You can install `rustfmt` locally with
 
 ```shell
-cargo install rustfmt --version <rustfmt-version> --force
+cargo install rustfmt --vers <rustfmt-version> --force
 ```
 
 where `<rustfmt-version>` is the supported version of the formatter.


### PR DESCRIPTION
To cargo install a version, we need the `--vers` option; not `--version`