### PR TITLE
Update dependencies

### DIFF
--- a/misc/lock.py
+++ b/misc/lock.py
@@ -1,5 +1,23 @@
 #!/usr/bin/env python
 
+# Script allowing to execute one or more linters.
+# Runs from the project root directory.
+# It is assumed that the HTML pages are already built and are located in $SRC_DIR.
+
+# Copyright 2017 The Exonum Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """
 Script that transforms the output of `pip freeze` to contain only dependencies
 related to a particular requirements file.

--- a/requirements.lock
+++ b/requirements.lock
@@ -3,16 +3,16 @@ Jinja2==2.9.6
 mkdocs==0.16.3
 Pygments==2.2.0
 pygments-github-lexers==0.0.5
-mkdocs-material==1.7.3
+mkdocs-material==1.9.0
 ## The following requirements were added by pip freeze:
 backports-abc==0.5
-certifi==2017.4.17
+certifi==2017.7.27.1
 click==6.7
 livereload==2.5.1
-Markdown==2.6.8
+Markdown==2.6.9
 MarkupSafe==1.0
-pymdown-extensions==3.4
+pymdown-extensions==4.0
 PyYAML==3.12
 singledispatch==3.4.0.3
 six==1.10.0
-tornado==4.5.1
+tornado==4.5.2


### PR DESCRIPTION
This PR updates dependencies recorded in `requirements.lock`. In particular, new `mkdocs-material` version leads to nicer admonitions:

![new-admonitions](https://user-images.githubusercontent.com/9612896/30251528-c13e6656-9669-11e7-97df-5f771827bd97.png)

Still, the production deployment is not automated yet, but locked dependencies can simplify the process.