### PR TITLE
Transaction info clarifications

### DIFF
--- a/src/advanced/node-management.md
+++ b/src/advanced/node-management.md
@@ -179,7 +179,7 @@ Searches for a transaction, either committed or uncommitted, by the hash.
 !!! warning "Quirky behavior"
     As of Exonum 0.2, the returned information about a transaction is only
     accurate if the transaction type redefines the default [`info()`][info-method]
-    implementation, for example, to return the JSON serialization of the transaction.
+    implementation, for example, to return JSON serialization of the transaction.
     If `info()` is *not* redefined, the
     endpoint will always return `null` as the transaction information.
 

--- a/src/advanced/node-management.md
+++ b/src/advanced/node-management.md
@@ -35,9 +35,9 @@ appropriate length. `Hash` and `PublicKey` consist of 32 bytes.
 `PeerAddress` is a string containing address in `IP:port` format. `IP` is IPv4
 address formatted as 4 octets separated by points.
 
-### OutgiongConnectionState
+### OutgoingConnectionState
 
-`OutgiongConnectionState` is a JSON object with the following fields:
+`OutgoingConnectionState` is a JSON object with the following fields:
 
 - **type**: string  
   Connection type, can be:
@@ -55,7 +55,7 @@ address formatted as 4 octets separated by points.
 
 - **public_key**: ?PublicKey  
   The public key of the peer or `null` if the public key is unknown
-- **state**: OutgiongConnectionState  
+- **state**: OutgoingConnectionState  
   Current connection state
 
 ### ServiceInfo

--- a/src/advanced/node-management.md
+++ b/src/advanced/node-management.md
@@ -176,6 +176,13 @@ GET {system_base_path}/transactions/{transaction_hash}
 
 Searches for a transaction, either committed or uncommitted, by the hash.
 
+!!! warning "Quirky behavior"
+    As of Exonum 0.2, the returned information about a transaction is only
+    accurate if the transaction type redefines the default [`info()`][info-method]
+    implementation, for example, to return the JSON serialization of the transaction.
+    If `info()` is *not* redefined, the
+    endpoint will always return `null` as the transaction information.
+
 #### Parameters
 
 - **transaction_hash**: Hash  
@@ -609,3 +616,4 @@ descending order according to their heights.
 
 [closurec]: https://github.com/google/closure-compiler/wiki/Annotating-JavaScript-for-the-Closure-Compiler
 [github_explorer]: https://github.com/exonum/exonum/blob/master/exonum/src/api/public/blockhain_explorer.rs
+[info-method]: ../architecture/transactions.md#info

--- a/src/architecture/transactions.md
+++ b/src/architecture/transactions.md
@@ -221,6 +221,24 @@ The method has no access to the blockchain state, same as `verify`.
 `info()` is used within the core Exonum framework
 [in the blockchain explorer](../advanced/node-management#transaction).
 
+!!! tip
+    In most cases, you may implement `info()` to return the JSON serialization
+    of the transaction:
+
+    ```rust
+    impl Transaction for YourTransactionType {
+        // other methods
+
+        fn info(&self) -> serde_json::Value {
+            serde_json::to_value(self).expect("Cannot serialize transaction to JSON")
+        }
+    }
+    ```
+
+    JSON serialization is automatically implemented for all transactions
+    defined with the `message!` macro, so no additional coding is required
+    for them.
+
 ## Lifecycle
 
 ### 1. Creation

--- a/src/architecture/transactions.md
+++ b/src/architecture/transactions.md
@@ -215,14 +215,14 @@ of the validators.
 fn info(&self) -> ::serde_json::Value
 ```
 
-The `info` method returns the useful information (from service developers point
-of view) about the transaction in the JSON format.
+The `info` method returns useful information (from the service developer’s point
+of view) about the transaction in JSON format.
 The method has no access to the blockchain state, same as `verify`.
-`info()` is used within the core Exonum framework
+`info()` is used within the core of Exonum framework
 [in the blockchain explorer](../advanced/node-management#transaction).
 
 !!! tip
-    In most cases, you may implement `info()` to return the JSON serialization
+    In most cases, you may implement `info()` to return JSON serialization
     of the transaction:
 
     ```rust

--- a/src/architecture/transactions.md
+++ b/src/architecture/transactions.md
@@ -218,6 +218,8 @@ fn info(&self) -> ::serde_json::Value
 The `info` method returns the useful information (from service developers point
 of view) about the transaction in the JSON format.
 The method has no access to the blockchain state, same as `verify`.
+`info()` is used within the core Exonum framework
+[in the blockchain explorer](../advanced/node-management#transaction).
 
 ## Lifecycle
 


### PR DESCRIPTION
This PR clarifies `Transaction.info()` behavior and its use in the blockchain explorer.

Related to exonum/exonum#343.