### PR TITLE
Clarify parameters for the blocks-in-range request

### DIFF
--- a/src/advanced/node-management.md
+++ b/src/advanced/node-management.md
@@ -544,11 +544,11 @@ Returns the headers of the consecutive `count` blocks up to the `latest` height.
   The number of blocks to return. Should not be greater than
   [`MAX_BLOCKS_PER_REQUEST`][github_explorer]
 - **skip_empty_blocks**: bool=  
-  If `true`, then only non-empty blocks are returned. Default value is `false`
+  If `true`, then only non-empty blocks are returned. The default value is `false`
 - **latest**: integer=  
   The maximum height of the returned blocks. The blocks are returned
   in reverse order, starting from the `latest` and at least up to the `latest -
-  count + 1`. Default value is the height of the latest block in the blockchain
+  count + 1`. The default value is the height of the latest block in the blockchain
 
 #### Response
 

--- a/src/advanced/node-management.md
+++ b/src/advanced/node-management.md
@@ -543,12 +543,12 @@ Returns the headers of the consecutive `count` blocks up to the `latest` height.
 - **count**: integer  
   The number of blocks to return. Should not be greater than
   [`MAX_BLOCKS_PER_REQUEST`][github_explorer]
-- **skip_empty_blocks**: bool  
-  If `true`, then only non-empty blocks are returned
-- **latest**: integer  
+- **skip_empty_blocks**: bool=  
+  If `true`, then only non-empty blocks are returned. Default value is `false`
+- **latest**: integer=  
   The maximum height of the returned blocks. The blocks are returned
   in reverse order, starting from the `latest` and at least up to the `latest -
-  count + 1`
+  count + 1`. Default value is the height of the latest block in the blockchain
 
 #### Response
 


### PR DESCRIPTION
Imagine, you have a chain with empty first 1001 blocks, you want to retrieve all non-empty blocks. You pull blocks starting from 0 with increment of 1000. There is no way to say whether you have exhausted all blocks in the chain or you haven't reached non-empty blocks yet. So should you keep pulling or stop? Thus one needs to start pulling from the end until 0 is reached. It is unclear from the documentation that skipping the `latest` param will result in a pull from the very end of the chain.