### PR TITLE
Update info on event processing library

### DIFF
--- a/src/advanced/consensus/specification.md
+++ b/src/advanced/consensus/specification.md
@@ -181,7 +181,7 @@ The steps performed at each stage are described [below](#stage-processing).
 
 ## Message Processing
 
-Nodes use a message queue based on [the Mio library][mio_lib] for message processing.
+Nodes use a message queue based on [the Tokio library][tokio-lib] for message processing.
 Incoming requests and consensus messages are placed in the queue when they are
 received. The same queue is used for processing timeouts. Timeouts are
 implemented as messages looped to the node itself.
@@ -456,5 +456,5 @@ Then the algorithm described above has the following properties:
 [wiki_bft]: https://en.wikipedia.org/wiki/Byzantine_fault_tolerance
 [partial_ordering]: https://en.wikipedia.org/wiki/Partially_ordered_set#Formal_definition
 [message_source]: https://github.com/exonum/exonum/blob/master/exonum/src/messages/protocol.rs
-[mio_lib]: https://github.com/carllerche/mio
+[tokio-lib]: https://tokio.rs/
 [partial_synchrony]: http://groups.csail.mit.edu/tds/papers/Lynch/podc84-DLS.pdf

--- a/src/advanced/network.md
+++ b/src/advanced/network.md
@@ -43,7 +43,7 @@ has been really authorized by a supermajority of validators.
 
 Full nodes use the [Exonum binary serialization format](../glossary.md#binary-serialization)
 over TCP to communicate with each other.
-Mio library is used for event multiplexing. Each node has
+[The Tokio library][tokio-lib] is used for event multiplexing. Each node has
 an event loop, through which the node receives events about new messages from
 the external network, timeouts, and new transactions received via REST API.
 
@@ -154,3 +154,5 @@ to be unique within a specific Exonum blockchain.
     of the corresponding service transaction, as it can be inferred from the
     semantics of POST requests. The GET endpoint consumes `{config_hash}` param,
     which is specified as a part of the URL path.
+
+[tokio-lib]: https://tokio.rs/


### PR DESCRIPTION
The library has changed from from `mio` to `tokio` in exonum/exonum#300.