### PR TITLE
Update info on persistence according to 0.3 changes

### DIFF
--- a/src/architecture/services.md
+++ b/src/architecture/services.md
@@ -350,13 +350,16 @@ only it is a string instead of an integer.
   in the `services_configs` variable
 - To compute API endpoints for the service. All service endpoints
   are mounted on `/api/services/{service_name}`
+- In naming service [tables](../glossary.md#table). By convention, table names
+  should start with `service_name` followed by a period `.`
 
 !!! note "Example"
     [The Bitcoin anchoring service](../advanced/bitcoin-anchoring.md)
     defines `service_name` as `"btc_anchoring"`. Thus, API endpoints of the
     service
-    are available on `/api/services/btc_anchoring/`, and its configuration is
-    stored in the `services.btc_anchoring` section of the overall configuration.
+    are available on `/api/services/btc_anchoring/`, its configuration is
+    stored in the `services.btc_anchoring` section of the overall configuration,
+    and its tables have names starting with `"btc_anchoring."`.
 
 ### State Hash
 

--- a/src/architecture/services.md
+++ b/src/architecture/services.md
@@ -148,8 +148,7 @@ cryptocurrency service persists account balances, which are changed by transfer
 and issuance transactions.
 
 Exonum persists blockchain state in a global key-value storage implemented with
-one of the supported backends - [LevelDB][leveldb] (used by default) and
-[RocksDB][rocksdb] (introduced as of Exonum 0.2). Each service needs to define a
+[RocksDB][rocksdb]. Each service needs to define a
 set of data collections
 (*tables*), in which the service persists the service-specific data;
 these tables abstract away the need for the service to deal with the blockchain
@@ -518,7 +517,6 @@ running the service might not know this information.
 [iron]: http://ironframework.io/
 [wiki:atomicity]: https://en.wikipedia.org/wiki/Atomicity_(database_systems)
 [wiki:crypto-commit]: https://en.wikipedia.org/wiki/Commitment_scheme
-[leveldb]: http://leveldb.org/
 [rocksdb]: http://rocksdb.org
 [wiki:pki]: https://en.wikipedia.org/wiki/Public_key_infrastructure
 [service.rs]: https://github.com/exonum/exonum/blob/master/exonum/src/blockchain/service.rs

--- a/src/architecture/storage.md
+++ b/src/architecture/storage.md
@@ -226,20 +226,24 @@ Every table is uniquely identified by a compound identifier, which is used
 to map table keys into a column family and its keys in the underlying
 low-level storage. A table identifier consists of 2 parts:
 
-- String name, which is mapped 1-to-1 to a column family.
+- **String name,** which is mapped 1-to-1 to a column family.
   The name may contain uppercase and lowercase Latin letters, digits,
-  and underscores `_`.
-- Optional prefix presented as a sequence of bytes (`Vec<u8>` in Rust terms).
+  underscores `_`, and periods `.`. By convention, table names in services should
+  start with [the service name][service-name] and a period. For example,
+  the only table in the cryptocurrency tutorial is named `cryptocurrency.wallets`,
+  where `cryptocurrency` is the service name, and `wallets` is the own name
+  of the table.
+- **Optional prefix** presented as a sequence of bytes (`Vec<u8>` in Rust terms).
 
 If the prefix is present, the column family identified by the table name
 stores a *group* of tables, rather than a single table.
 In this case, prefixes are used to distinguish tables within the group.
 
 !!! note "Example"
-    Key `key` at the table with name `crypto` and prefix `BTC`
+    Key `key` at the table with name `exchange.crypto` and prefix `BTC`
     (`0x42 0x54 0x43` in ASCII) matches key
     `0x42 0x54 0x43 | key` in the column family in RocksDB named
-    `crypto`.
+    `exchange.crypto`.
 
 !!! warning
     It is strongly advised not to admit
@@ -341,3 +345,4 @@ content together with the tables being indexed.
 [fork]: https://github.com/exonum/exonum/blob/d9e2fdc3d5a1d4e36078a7fbf1a9198d1b83cd5d/exonum/src/storage/db.rs#L104
 [col-family]: https://github.com/facebook/rocksdb/wiki/Column-Families
 [blockchain-schema]: https://github.com/exonum/exonum/blob/master/exonum/src/blockchain/schema.rs
+[service-name]: services.md#service-identifiers

--- a/src/architecture/storage.md
+++ b/src/architecture/storage.md
@@ -209,7 +209,7 @@ All the tables functionality is reduced to these atomic call types.
 
 As of Exonum 0.3, the main database engine is [RocksDB][rocks-db].
 In versions 0.1 and 0.2, [LevelDB][level-db] was supported as well, but
-since 0.3, its support has been dropped.
+since 0.3 its support has been dropped.
 
 Values from different tables are stored in column families in the low-level storage,
 wherein the keys are represented as

--- a/src/get-started/create-service.md
+++ b/src/get-started/create-service.md
@@ -109,7 +109,7 @@ let blockchain = Blockchain::new(Box::new(db), services);
 
 We use `MemoryDB` to store our data in the code above. `MemoryDB` is an
 in-memory database implementation useful for development and testing purposes.
-There is LevelDB and RocksDB support as well that is recommendable for
+There is RocksDB support as well that is recommendable for
 production applications.
 
 A minimal blockchain is ready, but it is pretty much useless, because there is

--- a/src/get-started/design-overview.md
+++ b/src/get-started/design-overview.md
@@ -218,11 +218,11 @@ which more than 1/3 (but less than 2/3) of the validators are compromised.
     See the [*Data Storage*](../architecture/storage.md) article
     for more details.
 
-### LevelDB and RocksDB
+### RocksDB
 
-[LevelDB][level-db] and [RocksDB][rocks-db] are used to persist locally the data
-that transactions operate with. They provide high efficiency and minimal
-storage overhead.
+[RocksDB][rocks-db] is used to persist locally the data
+that transactions operate with. This storage engine provides high efficiency
+and minimal storage overhead.
 
 ### Table Types
 
@@ -466,7 +466,6 @@ for signing anchoring transactions in Bitcoin.
 
 [wiki:oltp]: https://en.wikipedia.org/wiki/Online_transaction_processing
 [wiki:state-machine-repl]: https://en.wikipedia.org/wiki/State_machine_replication
-[level-db]: http://leveldb.org/
 [rocks-db]: http://rocksdb.org/
 [wiki:sha256]: https://en.wikipedia.org/wiki/SHA-2
 [wiki:ed25519]: https://en.wikipedia.org/wiki/EdDSA

--- a/src/get-started/install.md
+++ b/src/get-started/install.md
@@ -6,7 +6,7 @@ This document details how to setup development environment for contributing
 to these projects, testing them, and developing using Exonum.
 
 !!! note
-    As of version 0.1, you need to compile the core locally for every application
+    As of version 0.3, you need to compile the core locally for every application
     that depends on it. [Cargo][cargo] (the Rust package manager) takes care
     of most things, but you still need to have dependencies
     installed locally as described below for the core to compile.
@@ -18,15 +18,14 @@ to these projects, testing them, and developing using Exonum.
 
 Exonum depends on the following third-party system libraries:
 
-- [LevelDB][leveldb] (persistent storage)
 - [RocksDB][rocksdb] (persistent storage)
 - [libsodium][libsodium] (cryptography engine)
 
-LevelDB and RocksDB are used as alternative storage engines, with LevelDB
-used by default. You need to install only the storage engine(s) you are
-intending to use.
+!!! note
+    Before version 0.3, Exonum supported [LevelDB][leveldb] as an alternative
+    storage engine. In [0.3 release][rel0.3.0], the support for LevelDB was dropped.
 
-You can find instructions how to install them on the various environments
+You can find instructions how to install dependencies in various environments
 below.
 
 ### MacOS
@@ -34,7 +33,7 @@ below.
 Install the necessary libraries using [Homebrew][homebrew]:
 
 ```shell
-brew install libsodium leveldb rocksdb pkg-config
+brew install libsodium rocksdb pkg-config
 ```
 
 ### Linux
@@ -44,7 +43,7 @@ use
 
 ```shell
 apt-get install build-essential libsodium-dev \
-    libleveldb-dev librocksdb-dev pkg-config
+    librocksdb-dev pkg-config
 ```
 
 Package names and installation methods may differ in other Linux distributives;
@@ -87,26 +86,6 @@ You may also run the extended test suite located in the `sandbox` directory:
 cargo test --manifest-path sandbox/Cargo.toml
 ```
 
-Exonum supports RocksDB as an alternative data storage since version [0.2.0][rel0.2.0].
-To enable RocksDB support you need to pass additional parameter to Cargo:
-
-```shell
-cargo test --manifest-path exonum/Cargo.toml --features rocksdb
-```
-
-and for extended test suite:
-
-```shell
-cargo test --manifest-path sandbox/Cargo.toml --features rocksdb
-```
-
-If you want to use Exonum framework with RocksDB support as a dependency
-in your project, you should add the following line into `Cargo.toml`:
-
-```toml
-exonum = { version = "0.2.0", features = ["rocksdb"] }
-```
-
 ## Non-Rust Components
 
 ### Light Client Library
@@ -144,4 +123,4 @@ guide on how to develop applications on top of the Exonum framework.
 [karma]: http://karma-runner.github.io/1.0/index.html
 [istanbul]: https://istanbul.js.org/
 [babel]: http://babeljs.io/
-[rel0.2.0]: https://github.com/exonum/exonum/releases/tag/v0.2
+[rel0.3.0]: https://github.com/exonum/exonum/releases/tag/v0.3

--- a/src/glossary.md
+++ b/src/glossary.md
@@ -95,7 +95,7 @@ only
 the transactions log) is identical for all full nodes.
 
 In Exonum the blockchain state is implemented as a key-value storage. It is
-persisted using [LevelDB][leveldb] or [RocksDB][rocksdb]. The parts of the
+persisted using [RocksDB][rocksdb]. The parts of the
 storage correspond to
 [tables](#table) used by [the core](#core) and [services](#service).
 
@@ -539,7 +539,6 @@ is reasonably small, consisting of 4–15 nodes.
 [wiki:pkc]: https://en.wikipedia.org/wiki/Public-key_cryptography
 [wiki:non-rep]: https://en.wikipedia.org/wiki/Non-repudiation
 [wiki:acid]: https://en.wikipedia.org/wiki/ACID
-[leveldb]: http://leveldb.org/
 [rocksdb]: http://rocksdb.org
 [exonum]: https://github.com/exonum/exonum/
 [wiki:mt]: https://en.wikipedia.org/wiki/Merkle_tree


### PR DESCRIPTION
This PR updates information in docs about the persistence engine used by Exonum. In particular, LevelDB support is mentioned as removed.