### PR TITLE
Theme update

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,26 +1,27 @@
 site_name: Exonum Documentation
 docs_dir: src
-theme: material
-theme_dir: theme
+theme:
+  name: material
+  favicon: 'assets/images/favicon.ico'
+  logo: 'assets/images/logo.svg" alt="Exonum Logo'
+  custom_dir: theme
+  palette:
+    primary: 'light green'
+    accent: 'lime'
+
 extra_css:
   - assets/stylesheets/extra.css
 repo_name: 'exonum/exonum'
 repo_url: 'https://github.com/exonum/exonum'
 
 site_url: 'https://exonum.com/doc/'
-site_author: 'BitFury Group'
+site_author: 'Exonum Team'
 site_description: Exonum is a blockchain framework that allows to build secure permissioned blockchain applications.
-site_favicon: 'assets/images/favicon.ico'
 
 copyright: © 2017 Exonum Team. Available under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/" rel="license">CC BY-NC-SA 4.0</a> license
 
 extra:
   og_image: 'assets/images/logo-docs.png'
-  logo: 'assets/images/logo.svg" alt="Exonum Logo'
-  github_edit_url: https://github.com/exonum/exonum-doc/edit/master/src/
-  palette:
-    primary: 'light green'
-    accent: 'lime'
   social:
     - type: 'github'
       link: 'https://github.com/exonum'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,7 @@ extra_css:
   - assets/stylesheets/extra.css
 repo_name: 'exonum/exonum'
 repo_url: 'https://github.com/exonum/exonum'
+edit_uri: 'doc/blob/master/src'
 
 site_url: 'https://exonum.com/doc/'
 site_author: 'Exonum Team'

--- a/requirements.lock
+++ b/requirements.lock
@@ -1,18 +1,18 @@
 # Main requirements
-Jinja2==2.9.6
-mkdocs==0.16.3
+Jinja2==2.10
+mkdocs==0.17.2
 Pygments==2.2.0
 pygments-github-lexers==0.0.5
-mkdocs-material==1.9.0
+mkdocs-material==2.2.5
 ## The following requirements were added by pip freeze:
 backports-abc==0.5
-certifi==2017.7.27.1
+certifi==2017.11.5
 click==6.7
 livereload==2.5.1
-Markdown==2.6.9
+Markdown==2.6.10
 MarkupSafe==1.0
-pymdown-extensions==4.0
+pymdown-extensions==4.7
 PyYAML==3.12
 singledispatch==3.4.0.3
-six==1.10.0
+six==1.11.0
 tornado==4.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Main requirements
 Jinja2~=2.8
-mkdocs~=0.16
+mkdocs~=0.17.1
 Pygments~=2.2
 pygments-github-lexers~=0.0.5
-mkdocs-material~=1.7,<1.10.0
+mkdocs-material~=2.2

--- a/theme/assets/stylesheets/extra.css
+++ b/theme/assets/stylesheets/extra.css
@@ -1,10 +1,4 @@
 /* Theme overrides. */
-.admonition {
-  background: none !important;
-  /* Same raised box shadow as for tables. */
-  box-shadow: 0 2px 2px 0 rgba(0,0,0,.14),0 1px 5px 0 rgba(0,0,0,.12),0 3px 1px -2px rgba(0,0,0,.2);
-}
-
 .md-typeset .admonition table:not([class]) {
   box-shadow: none; /* Remove box shadow from tables in admonitions, it looks ugly. */
 }
@@ -15,15 +9,4 @@
 }
 .md-typeset .admonition .md-typeset__table {
   padding: 0;
-}
-
-/* New elements. */
-
-.edit-on-github {
-  font-size: 80%;
-}
-.edit-on-github .md-icon {
-  font-size: 120%;
-  vertical-align: -3px;
-  margin-right: 2px;
 }

--- a/theme/main.html
+++ b/theme/main.html
@@ -2,15 +2,10 @@
 
 {% block htmltitle %}
   {% if page and page.meta.title %}
-    <title>{{ page.meta.title | first }} - {{ config.site_name }}</title>
+    <title>{{ page.meta.title }} - {{ config.site_name }}</title>
   {% else %}
     {{- super() }}
   {% endif %}
-{% endblock %}
-
-{% block content %}
-  <a class="edit-on-github" href="{{ config.extra.github_edit_url }}{{ page.input_path | replace('\\', '/') }}" title="Edit page source on GitHub"><span class="md-icon">edit</span>Edit on GitHub</a>
-  {{- super() }}
 {% endblock %}
 
 {%- block site_meta %}
@@ -27,7 +22,7 @@
 
 {% block extrahead %}
   {% if page and page.meta.title %}
-    {% set title = page.meta.title | first + ' - ' + config.site_name %}
+    {% set title = page.meta.title + ' - ' + config.site_name %}
   {% else %}
     {% set title = page.title + ' - ' + config.site_name
       if not page.is_homepage

--- a/theme/main.html
+++ b/theme/main.html
@@ -51,3 +51,8 @@
   <meta name="twitter:description" content="{{ description }}">
   {% endif %}
 {% endblock %}
+
+{#- Patches the "Edit this page" link to reference a proper GitHub repository #}
+{% block content %}
+  {{- super() | replace(page.edit_url, page.edit_url | replace('exonum/doc', 'exonum-doc')) }}
+{% endblock %}


### PR DESCRIPTION
This PR updates documentation to the newest version of `mkdocs-material`. It looks pretty neat:

![mkdocs-material-2 2](https://user-images.githubusercontent.com/9612896/34255398-3679a928-e659-11e7-8164-69c363180dba.png)

The only problem I have with the update is that the links on the right navigation (Table of Contents) panel flicker on hover in Firefox (57.0.2, Win 8.1). This seems to be a trouble with the Firefox rendering engine (specifically, processing of a combination of `transform` and `transition` CSS attributes), not the theme, though.