### PR TITLE
Theme update addons

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,8 @@ markdown_extensions:
   - admonition
   - meta
   - pymdownx.superfences
+  - toc:
+      permalink: true
 pages:
   # Short description of Exonum, documentation and how to use it
   - 'Home': 'index.md'

--- a/theme/main.html
+++ b/theme/main.html
@@ -42,6 +42,7 @@
   <meta name="og:type" content="article">
   <meta name="og:image" content="{{ config.site_url }}{{ config.extra.og_image }}">
   <meta name="og:image:secure_url" content="{{ config.site_url }}{{ config.extra.og_image }}">
+  <meta name="og:site_name" content="{{ config.site_name }}">
   <meta name="twitter:card" content="summary">
   {% set twitter_site = config.extra.social
     | selectattr('type', 'equalto', 'twitter')


### PR DESCRIPTION
This PR updates a theme a little bit more, continuing from #105:

- [The `permalink` extension](https://squidfunk.github.io/mkdocs-material/extensions/permalinks/) is enabled, allowing to easily link to sections of articles
- OpenGraph [`site_name` attribute](http://ogp.me/#optional) is added