### PR TITLE
Remove `Transaction::info` mentions

### DIFF
--- a/src/advanced/node-management.md
+++ b/src/advanced/node-management.md
@@ -176,13 +176,6 @@ GET {system_base_path}/transactions/{transaction_hash}
 
 Searches for a transaction, either committed or uncommitted, by the hash.
 
-!!! warning "Quirky behavior"
-    As of Exonum 0.2, the returned information about a transaction is only
-    accurate if the transaction type redefines the default [`info()`][info-method]
-    implementation, for example, to return JSON serialization of the transaction.
-    If `info()` is *not* redefined, the
-    endpoint will always return `null` as the transaction information.
-
 #### Parameters
 
 - **transaction_hash**: Hash  
@@ -616,4 +609,3 @@ descending order according to their heights.
 
 [closurec]: https://github.com/google/closure-compiler/wiki/Annotating-JavaScript-for-the-Closure-Compiler
 [github_explorer]: https://github.com/exonum/exonum/blob/master/exonum/src/api/public/blockhain_explorer.rs
-[info-method]: ../architecture/transactions.md#info

--- a/src/architecture/transactions.md
+++ b/src/architecture/transactions.md
@@ -126,8 +126,8 @@ according to the transaction specification in the service.
 
 ## Interface
 
-Transaction interface defines 3 methods: [`verify`](#verify),
-[`execute`](#execute) and [`info`](#info).
+Transaction interface defines 2 methods: [`verify`](#verify) and
+[`execute`](#execute).
 
 !!! tip
     From the Rust perspective, `Transaction` is a [trait][rust-trait].
@@ -208,36 +208,6 @@ of the validators.
     [services cannot directly access each other’s endpoints](services.md#limitations).
     In this model, preliminary
     checks are the most robust way to organize transaction execution.
-
-### Info
-
-```rust
-fn info(&self) -> ::serde_json::Value
-```
-
-The `info` method returns useful information (from the service developer’s point
-of view) about the transaction in JSON format.
-The method has no access to the blockchain state, same as `verify`.
-`info()` is used within the core of Exonum framework
-[in the blockchain explorer](../advanced/node-management#transaction).
-
-!!! tip
-    In most cases, you may implement `info()` to return JSON serialization
-    of the transaction:
-
-    ```rust
-    impl Transaction for YourTransactionType {
-        // other methods
-
-        fn info(&self) -> serde_json::Value {
-            serde_json::to_value(self).expect("Cannot serialize transaction to JSON")
-        }
-    }
-    ```
-
-    JSON serialization is automatically implemented for all transactions
-    defined with the `message!` macro, so no additional coding is required
-    for them.
 
 ## Lifecycle
 

--- a/src/get-started/create-service.md
+++ b/src/get-started/create-service.md
@@ -419,21 +419,6 @@ impl Transaction for TxTransfer {
 }
 ```
 
-In order for transactions to be properly displayed [in the blockchain explorer][explorer],
-we also should redefine the [`info()` method][tx-info]. The implementation is the
-same for both transactions and looks like this:
-
-```rust
-impl Transaction for TxCreateWallet {
-    // `verify()` and `execute()` code...
-
-    fn info(&self) -> serde_json::Value {
-        serde_json::to_value(&self)
-            .expect("Cannot serialize transaction to JSON")
-    }
-}
-```
-
 ## Implement API
 
 Finally, we need to implement the node API with the help of [Iron framework][iron].


### PR DESCRIPTION
This PR removes mentions of `Transaction::info` throughout documentation. The mentions in the tutorial are removed too; although the tutorial code itself is not yet updated, the changes are fairly predictable.

Closes #147.