### PR TITLE
Contributing clarifications

### DIFF
--- a/src/contributing.md
+++ b/src/contributing.md
@@ -48,6 +48,11 @@ Issues are commonly tagged by their relevance,
 topic and milestone, which should provide some insight into most topical
 issues relevant to your expertise.
 
+Another option with low entry barrier is contributing to Exonum documentation,
+which is also [open-sourced](https://github.com/exonum/exonum-doc).
+You can jump to the source of a particular documentation page by clicking
+a pencil icon at the top of the page.
+
 !!! tip
     Besides GitHub, Exonum issues and solutions are discussed on [gitter][gitter]
     and [Reddit][reddit].

--- a/src/contributing.md
+++ b/src/contributing.md
@@ -78,10 +78,6 @@ for example `refs #1234`, or `fixes #4321`.
 Using the `fixes` or `closes` keywords will cause the corresponding issue
 to be closed when the pull request is merged.
 
-!!! tip
-    Please refer to the [Git manual](https://git-scm.com/doc) for more information
-    about Git.
-
 ### Testing PRs Locally
 
 Every Exonum repository features test suite(s) and continuous integration (CI)


### PR DESCRIPTION
This PR adds a mention of documentation as a contribution option, and removes a superfluous tip about git.

See #160 and #161 for context.