### PR TITLE
Remove static lifetime specifier for `service_name`

### DIFF
--- a/src/architecture/services.md
+++ b/src/architecture/services.md
@@ -329,7 +329,7 @@ a service developer.
 
 ```rust
 fn service_id(&self) -> u16;
-fn service_name(&self) -> &'static str;
+fn service_name(&self) -> &str;
 ```
 
 `service_id` returns a 2-byte service identifier, which needs to be unique


### PR DESCRIPTION
This PR removes the `'static` lifetime from the `service_name` method. For now, it is confined to the service page; the remaining mention in the Create Service tutorial can be dealt with separately.

Related to exonum/exonum#485.