### PR TITLE
Add archetypeVersion option in get-started/java-binding [ECR-1882]

### DIFF
--- a/src/get-started/java-binding.md
+++ b/src/get-started/java-binding.md
@@ -13,6 +13,7 @@ $ mvn archetype:generate \
     -DinteractiveMode=false \
     -DarchetypeGroupId=com.exonum.binding \
     -DarchetypeArtifactId=exonum-java-binding-service-archetype \
+    -DarchetypeVersion=0.1.2 \
     -DgroupId=com.example.myservice \
     -DartifactId=my-service \
     -Dversion=1.0


### PR DESCRIPTION
Downside of this change - we're going to need to update this field each release for now.