### PR TITLE
Use latest EJB version in Javadoc

### DIFF
--- a/src/get-started/java-binding.md
+++ b/src/get-started/java-binding.md
@@ -380,25 +380,25 @@ service:
 - [Rust instruction](create-service.md)
 - [Java Binding App tutorial][app-tutorial]
 
-[abstractservice]: https://exonum.com/doc/api/java-binding-core/0.1/com/exonum/binding/service/AbstractService.html
+[abstractservice]: https://exonum.com/doc/api/java-binding-core/latest/com/exonum/binding/service/AbstractService.html
 [apicontrollertest]: https://github.com/exonum/exonum-java-binding/blob/v0.1/exonum-java-binding-cryptocurrency-demo/src/test/java/com/exonum/binding/cryptocurrency/ApiControllerTest.java
 [app-tutorial]: https://github.com/exonum/exonum-java-binding/blob/master/exonum-java-binding-core/rust/ejb-app/TUTORIAL.md
 [build-description]: https://github.com/exonum/exonum-java-binding/blob/master/exonum-java-binding-service-archetype/src/main/resources/archetype-resources/pom.xml
 [Exonum-services]: ../architecture/services.md
 [Guice]: https://github.com/google/guice/wiki/GettingStarted
 [how-to-build]: https://github.com/exonum/exonum-java-binding/blob/master/CONTRIBUTING.md#how-to-build
-[Memorydb]: https://exonum.com/doc/api/java-binding-core/0.1/com/exonum/binding/storage/database/MemoryDb.html
-[nodefake]: https://exonum.com/doc/api/java-binding-core/0.1/com/exonum/binding/service/NodeFake.html
-[schema]: https://exonum.com/doc/api/java-binding-core/0.1/com/exonum/binding/service/Schema.html
-[service]: https://exonum.com/doc/api/java-binding-core/0.1/com/exonum/binding/service/Service.html
-[standardserializers]: https://exonum.com/doc/api/java-proofs/0.1/com/exonum/binding/storage/serialization/StandardSerializers.html
-[storage-indices]: https://exonum.com/doc/api/java-binding-core/0.1/com/exonum/binding/storage/indices/package-summary.html
+[Memorydb]: https://exonum.com/doc/api/java-binding-core/latest/com/exonum/binding/storage/database/MemoryDb.html
+[nodefake]: https://exonum.com/doc/api/java-binding-core/latest/com/exonum/binding/service/NodeFake.html
+[schema]: https://exonum.com/doc/api/java-binding-core/latest/com/exonum/binding/service/Schema.html
+[service]: https://exonum.com/doc/api/java-binding-core/latest/com/exonum/binding/service/Service.html
+[standardserializers]: https://exonum.com/doc/api/java-proofs/latest/com/exonum/binding/storage/serialization/StandardSerializers.html
+[storage-indices]: https://exonum.com/doc/api/java-binding-core/latest/com/exonum/binding/storage/indices/package-summary.html
 [submittransaction]: https://github.com/exonum/exonum-java-binding/blob/v0.1/exonum-java-binding-cryptocurrency-demo/src/main/java/com/exonum/binding/cryptocurrency/ApiController.java
-[transaction]: https://exonum.com/doc/api/java-binding-core/0.1/com/exonum/binding/messages/Transaction.html
+[transaction]: https://exonum.com/doc/api/java-binding-core/latest/com/exonum/binding/messages/Transaction.html
 [transactions]: ../architecture/transactions.md
-[transactionconvererter]: https://exonum.com/doc/api/java-binding-core/0.1/com/exonum/binding/service/TransactionConverter.html
+[transactionconvererter]: https://exonum.com/doc/api/java-binding-core/latest/com/exonum/binding/service/TransactionConverter.html
 [vertx.io]: https://vertx.io/docs/vertx-web/java/#_basic_vert_x_web_concepts
 [vertx-web-client]: https://vertx.io/docs/vertx-web-client/java
 [maven-install]: https://maven.apache.org/install.html
-[cryptofunctions-ed25519]: https://exonum.com/doc/api/java-binding-core/0.1/com/exonum/binding/crypto/CryptoFunctions.html#ed25519--
-[createpublicapi]: https://exonum.com/doc/api/java-binding-core/0.1/com/exonum/binding/service/Service.html#createPublicApiHandlers-com.exonum.binding.service.Node-io.vertx.ext.web.Router-
+[cryptofunctions-ed25519]: https://exonum.com/doc/api/java-binding-core/latest/com/exonum/binding/crypto/CryptoFunctions.html#ed25519--
+[createpublicapi]: https://exonum.com/doc/api/java-binding-core/latest/com/exonum/binding/service/Service.html#createPublicApiHandlers-com.exonum.binding.service.Node-io.vertx.ext.web.Router-


### PR DESCRIPTION
@dmitry-timofeev Do we want to do something about such links as https://github.com/exonum/exonum-java-binding/blob/v0.1/exonum-java-binding-cryptocurrency-demo/src/test/java/com/exonum/binding/cryptocurrency/ApiControllerTest.java ? Do we want to change them to latest version manually each release? Or change `v0.1` to `master`? Or just leave it be?