### PR TITLE
Introduce round timeout increase in docs.

### DIFF
--- a/src/advanced/consensus/specification.md
+++ b/src/advanced/consensus/specification.md
@@ -351,9 +351,9 @@ round are placed into a separate queue (`queued`).
 
 - If the timeout does not match the current height and round, skip further
   timeout processing.
-- Add a timeout (its length is specified by the following formula
-  `first_round_timeout + (N-1)*first_round_timeout*q`) for the Nth round,
-  where `q = 0.1`.
+- Add a timeout for the `N`th round with the length
+  `first_round_timeout * (1 + (N - 1) * q)`,
+  where `q = 0.1` is the relative increase in a timeout after each round.
 - Process all messages from `queued` that have become relevant (their round
   and height coincide with the current ones).
 - If the node has a saved PoL, send a `Prevote` for `locked_propose` in the new

--- a/src/advanced/consensus/specification.md
+++ b/src/advanced/consensus/specification.md
@@ -75,7 +75,7 @@ message processing.
   Proposal timeout after a new block is committed to the blockchain locally.
 
 - `first_round_timeout`  
-  Initial interval between algorithm rounds at specific height.
+  Initial interval between algorithm rounds.
 
 - `status_timeout`  
   Interval between `Status` message broadcasts.
@@ -352,9 +352,8 @@ round are placed into a separate queue (`queued`).
 - If the timeout does not match the current height and round, skip further
   timeout processing.
 - Add a timeout (its length is specified by the following formula
-  `first_round_timeout + (N-1)*round_timeout_increase`) for the Nth round.
-  Where `round_timeout_increase` is constant percentage of
-  `first_round_timeout` (current value is 10%).
+  `first_round_timeout + (N-1)*first_round_timeout*q`) for the Nth round,
+  where `q = 0.1`.
 - Process all messages from `queued` that have become relevant (their round
   and height coincide with the current ones).
 - If the node has a saved PoL, send a `Prevote` for `locked_propose` in the new

--- a/src/advanced/consensus/specification.md
+++ b/src/advanced/consensus/specification.md
@@ -36,11 +36,11 @@ and -1/3 means less than one third.
 The consensus algorithm proceeds in rounds for each blockchain height
 (i.e., the number of blocks in the blockchain).
 Rounds are numbered from 1\. The onsets of rounds are determined
-by a fixed timetable:
+by the following timetable:
 
 - The first round starts after committing a block at the previous height
   to the blockchain
-- Rounds 2, 3, … start after regular intervals
+- Rounds 2, 3, … start after linearly increasing time intervals
 
 Rounds are not synchronized among nodes.
 
@@ -74,8 +74,8 @@ message processing.
 - `propose_timeout`  
   Proposal timeout after a new block is committed to the blockchain locally.
 
-- `round_timeout`  
-  Interval between algorithm rounds.
+- `first_round_timeout`  
+  Initial interval between algorithm rounds at specific height.
 
 - `status_timeout`  
   Interval between `Status` message broadcasts.
@@ -351,7 +351,10 @@ round are placed into a separate queue (`queued`).
 
 - If the timeout does not match the current height and round, skip further
   timeout processing.
-- Add a timeout (its length is specified by `round_timeout`) for the next round.
+- Add a timeout (its length is specified by the following formula
+  `first_round_timeout + (N-1)*round_timeout_increase`) for the Nth round.
+  Where `round_timeout_increase` is constant percentage of
+  `first_round_timeout` (current value is 10%).
 - Process all messages from `queued` that have become relevant (their round
   and height coincide with the current ones).
 - If the node has a saved PoL, send a `Prevote` for `locked_propose` in the new

--- a/src/architecture/configuration.md
+++ b/src/architecture/configuration.md
@@ -81,8 +81,8 @@ two parts:
   Peers exchange timeout (in ms)
 - **propose_timeout_threshold**  
   Amount of transactions in the pool to start using `min_propose_timeout`
-- **round_timeout**  
-  Timeout interval (ms) between rounds
+- **first_round_timeout**  
+  Timeout interval (ms) between first two rounds
 - **status_timeout**  
   Timeout interval (ms) for sending a `Status` message
 - **txs_block_limit**  

--- a/src/architecture/consensus.md
+++ b/src/architecture/consensus.md
@@ -59,9 +59,9 @@ The process of reaching consensus on the next block (at the blockchain height
 `H`) consists of several **rounds**, numbered from 1\. The first round starts
 once the
 validator commits the block at height `H - 1`. The onsets of rounds are
-determined
-by a fixed timetable: rounds start after regular intervals. As there is no
-global time, rounds may start at different time for different validators.
+determined by the following timetable: rounds start after linearly increasing
+with round number time intervals. As there is no global time,
+rounds may start at different time for different validators.
 
 When the round number `R` comes, the previous rounds are not completed.
 That is, round `R` means that the validator can process messages

--- a/src/architecture/consensus.md
+++ b/src/architecture/consensus.md
@@ -59,8 +59,9 @@ The process of reaching consensus on the next block (at the blockchain height
 `H`) consists of several **rounds**, numbered from 1\. The first round starts
 once the
 validator commits the block at height `H - 1`. The onsets of rounds are
-determined by the following timetable: rounds start after linearly increasing
-with round number time intervals. As there is no global time,
+determined by the following timetable: rounds start with time intervals
+that linearly increase with the round number.
+As there is no global time,
 rounds may start at different time for different validators.
 
 When the round number `R` comes, the previous rounds are not completed.


### PR DESCRIPTION
<!--
Please target the following branch:
- `master` if your pull request fixes bugs in the documentation, describes
  released features, etc. In other words,
  a pull request targeting `master` should be possible to merge and
  push to https://exonum.com/doc/ at any time.
- `develop` if your pull request describes features introduced into an upcoming
  version of Exonum. A request targeting `develop` should be pushed to
  https://exonum.com/doc/ no earlier than this upcoming version is released.
-->
https://github.com/exonum/exonum/pull/848