### PR TITLE
Document Service#afterCommit handler [ECR-2728]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,9 @@ cache:
 branches:
   only:
     - master
-    - develop
-    # tags
+    # Any develop (pre-release) branches, such as 'develop-ejb-0.4'
+    - /^develop-.*$/
+    # Tags
     - /^v\d+\.\d+(\.\d+)?(-\S*)?$/
 before_install:
   # Lock dependencies for branch builds

--- a/misc/cspell.json
+++ b/misc/cspell.json
@@ -38,6 +38,7 @@
     "Guice",
     "healthcheck",
     "HMACs",
+    "Javadoc",
     "junit",
     "keypair",
     "leveldb",

--- a/src/get-started/java-binding.md
+++ b/src/get-started/java-binding.md
@@ -107,7 +107,7 @@ implements [`Schema`][schema] interface; when implementing
 As Exonum storage accepts data in the form of byte arrays,
 storing user data requires serialization.
 Java Binding provides a set of built-in *serializers* that you can find
-at the [`StandardSerializers`][standardserializers] utility class.
+in the [`StandardSerializers`][standardserializers] utility class.
 The list of serializers covers the most often-used entities and includes:
 
 - Standard types: `boolean`, `float`, `double`, `byte[]` and `String`.
@@ -222,9 +222,9 @@ reference. Light clients also provide access to information on the
 [transaction][exonum-transaction] execution result
 (which may be either success or failure) to their users.
 
-### Blockchain events
+### Blockchain Events
 
-A service can also handle a block commit event, that occurs each time
+A service can also handle a block commit event that occurs each time
 the framework commits a new block. The framework delivers this event to
 implementations of [`Service#afterCommit(BlockCommittedEvent)`][service-after-commit]
 in each deployed service. Each node in the network processes that event 
@@ -427,9 +427,9 @@ service:
 ## Common Library
 
 Java Binding includes a library module that can be useful for Java client
-applications that interact with an Exonum service and
-does not have the dependency on Java Binding Core. The module contains Java
-classes obligatory for core that can now as well be easily applied in clients,
+applications that interact with an Exonum service. The module does not
+have the dependency on Java Binding Core, but it contains Java classes
+obligatory for core that can now as well be easily used in clients,
 if necessary.
 The library provides the ability to create transaction messages, check proofs,
 serialize/deserialize data and perform cryptographic operations.

--- a/src/get-started/java-binding.md
+++ b/src/get-started/java-binding.md
@@ -474,8 +474,10 @@ For using the library just include the dependency in your `pom.xml`:
 [nodefake]: https://exonum.com/doc/api/java-binding-core/latest/com/exonum/binding/service/NodeFake.html
 [schema]: https://exonum.com/doc/api/java-binding-core/latest/com/exonum/binding/service/Schema.html
 [service]: https://exonum.com/doc/api/java-binding-core/latest/com/exonum/binding/service/Service.html
-[service-after-commit]: https://exonum.com/doc/api/java-binding-core/latest/com/exonum/binding/service/Service.html <!--TODO: Insert the correct Javadoc -->
-[node-submit-transaction]: https://exonum.com/doc/api/java-binding-core/latest/com/exonum/binding/service/Node.html <!--TODO: Insert the correct Javadoc (once we merge messages) -->
+<!--TODO: Insert the correct Javadoc below -->
+[service-after-commit]: https://exonum.com/doc/api/java-binding-core/latest/com/exonum/binding/service/Service.html
+<!--TODO: Insert the correct Javadoc (once we merge messages): -->
+[node-submit-transaction]: https://exonum.com/doc/api/java-binding-core/latest/com/exonum/binding/service/Node.html
 [standardserializers]: https://exonum.com/doc/api/java-binding-common/latest/com/exonum/binding/common/serialization/StandardSerializers.html
 [storage-indices]: https://exonum.com/doc/api/java-binding-core/latest/com/exonum/binding/storage/indices/package-summary.html
 [submittransaction]: https://github.com/exonum/exonum-java-binding/blob/v0.3/exonum-java-binding-cryptocurrency-demo/src/main/java/com/exonum/binding/cryptocurrency/ApiController.java

--- a/src/get-started/java-binding.md
+++ b/src/get-started/java-binding.md
@@ -36,7 +36,7 @@ template. For more information see an [example][build-description].
 The service abstraction serves to extend the framework and implement the
 business logic of an application. The service defines the schema of the stored
 data that constitute the service state; transaction processing rules that can
-make changes to the stored data; handles events occurring in the ledger; 
+make changes to the stored data; handles events occurring in the ledger;
 and defines an API for external clients that allows interacting
 with the service from outside of the system. See more information on the
 software model of services in the [corresponding section][Exonum-services].
@@ -227,8 +227,8 @@ reference. Light clients also provide access to information on the
 A service can also handle a block commit event that occurs each time
 the framework commits a new block. The framework delivers this event to
 implementations of [`Service#afterCommit(BlockCommittedEvent)`][service-after-commit]
-in each deployed service. Each node in the network processes that event 
-independently from other nodes. The event includes a `Snapshot`, 
+in each deployed service. Each node in the network processes that event
+independently from other nodes. The event includes a `Snapshot`,
 allowing a read-only access to the database state _exactly_ after the commit
 of the corresponding block.
 
@@ -237,10 +237,10 @@ any changes in it, e.g., that a certain transaction is executed;
 or some condition is met. Services may also create and submit new transactions
 using [`Node#submitTransaction`][node-submittransaction]. Using this callback
 to notify other systems is another common use case, but the implementations
-must pay attention to **not** perform any blocking operations such as synchronous I/O
-in this handler, as it is invoked synchronously in the same thread that handles
-transactions. Blocking that thread will delay transaction processing on the node.
-
+must pay attention to **not** perform any blocking operations such as
+synchronous I/O in this handler, as it is invoked synchronously in the same
+thread that handles transactions. Blocking that thread will delay transaction
+processing on the node.
 
 ### External Service API
 

--- a/src/get-started/java-binding.md
+++ b/src/get-started/java-binding.md
@@ -227,15 +227,15 @@ reference. Light clients also provide access to information on the
 A service can also handle a block commit event that occurs each time
 the framework commits a new block. The framework delivers this event to
 implementations of [`Service#afterCommit(BlockCommittedEvent)`][service-after-commit]
-in each deployed service. Each node in the network processes that event
-independently from other nodes. The event includes a `Snapshot`,
+callback in each deployed service. Each node in the network processes
+that event independently from other nodes. The event includes a `Snapshot`,
 allowing a read-only access to the database state _exactly_ after the commit
 of the corresponding block.
 
 As services can read the database state in the handler, they may detect
 any changes in it, e.g., that a certain transaction is executed;
 or some condition is met. Services may also create and submit new transactions
-using [`Node#submitTransaction`][node-submittransaction]. Using this callback
+using [`Node#submitTransaction`][node-submit-transaction]. Using this callback
 to notify other systems is another common use case, but the implementations
 must pay attention to **not** perform any blocking operations such as
 synchronous I/O in this handler, as it is invoked synchronously in the same
@@ -429,7 +429,7 @@ service:
 Java Binding includes a library module that can be useful for Java client
 applications that interact with an Exonum service. The module does not
 have the dependency on Java Binding Core, but it contains Java classes
-obligatory for core that can now as well be easily used in clients,
+obligatory for the core that can now as well be easily used in clients,
 if necessary.
 The library provides the ability to create transaction messages, check proofs,
 serialize/deserialize data and perform cryptographic operations.
@@ -475,7 +475,7 @@ For using the library just include the dependency in your `pom.xml`:
 [schema]: https://exonum.com/doc/api/java-binding-core/latest/com/exonum/binding/service/Schema.html
 [service]: https://exonum.com/doc/api/java-binding-core/latest/com/exonum/binding/service/Service.html
 [service-after-commit]: https://exonum.com/doc/api/java-binding-core/latest/com/exonum/binding/service/Service.html <!--TODO: Insert the correct Javadoc -->
-[node-submittransaction]: https://exonum.com/doc/api/java-binding-core/latest/com/exonum/binding/service/Node.html <!--TODO: Insert the correct Javadoc (once we merge messages) -->
+[node-submit-transaction]: https://exonum.com/doc/api/java-binding-core/latest/com/exonum/binding/service/Node.html <!--TODO: Insert the correct Javadoc (once we merge messages) -->
 [standardserializers]: https://exonum.com/doc/api/java-binding-common/latest/com/exonum/binding/common/serialization/StandardSerializers.html
 [storage-indices]: https://exonum.com/doc/api/java-binding-core/latest/com/exonum/binding/storage/indices/package-summary.html
 [submittransaction]: https://github.com/exonum/exonum-java-binding/blob/v0.3/exonum-java-binding-cryptocurrency-demo/src/main/java/com/exonum/binding/cryptocurrency/ApiController.java


### PR DESCRIPTION
<!--
Please target the following branch:
- `master` if your pull request fixes bugs in the documentation, describes
  released features, etc. In other words,
  a pull request targeting `master` should be possible to merge and
  push to https://exonum.com/doc/ at any time.
- `develop` if your pull request describes features introduced into an upcoming
  version of Exonum. A request targeting `develop` should be pushed to
  https://exonum.com/doc/ no earlier than this upcoming version is released.
-->

### Overview
Adds documentation about `Service#afterCommit` usage. 

- [x] Rebase onto master once #248 is integrated
- [x] ~~Add proper Javadoc links once they are published~~ — delayed till we publish them