### PR TITLE
Add Core Schema API to EJB User Guide [ECR-2727]

### DIFF
--- a/src/get-started/java-binding.md
+++ b/src/get-started/java-binding.md
@@ -258,16 +258,13 @@ class. The following functionality is available:
   The map of transaction messages identified by their SHA-256 hashes. Both
   committed and in-pool (not yet processed) transactions are returned.
 - `getTxResults: ProofMapIndexProxy<HashCode, TransactionResult>`
-  The map with a key-value pair of a transaction hash and execution result.
-  It's also possible to get a `TransactionResult` of a single transaction by its
-  hash.
+  The map with of transaction execution results identified by corresponding
+  transaction SHA-256 hashes.
 - `getTxLocations: MapIndex<HashCode, TransactionLocation>`
-  Returns a map that keeps the transaction position inside the blockchain for
-  every transaction hash. It's also possible to get a `TransactionLocation` of
-  a single transaction by its hash.
+  The map of transaction positions inside the blockchain identified by
+  corresponding transaction SHA-256 hashes.
 - `getBlocks: MapIndex<HashCode, Block>`
-  The map that stores a block object for every block hash.  It's also possible
-  to get a single block object by its hash.
+  The map of block objects identified by corresponding block hashes.
 - `getLastBlock: Block`
   The latest committed block.
 - `getActualConfiguration: StoredConfiguration`
@@ -498,7 +495,8 @@ For using the library just include the dependency in your `pom.xml`:
 [abstractservice]: https://exonum.com/doc/api/java-binding-core/latest/com/exonum/binding/service/AbstractService.html
 [apicontrollertest]: https://github.com/exonum/exonum-java-binding/blob/v0.3/exonum-java-binding-cryptocurrency-demo/src/test/java/com/exonum/binding/cryptocurrency/ApiControllerTest.java
 [app-tutorial]: https://github.com/exonum/exonum-java-binding/blob/master/exonum-java-binding-core/rust/ejb-app/TUTORIAL.md
-[blockchain]: https://github.com/exonum/exonum-java-binding/0.4/master/exonum-java-binding-core/src/main/java/com/exonum/binding/blockchain/Blockchain.java
+<!-- TODO: change `blob` with `0.4` after the release OR insert a Javadoc link instead -->
+[blockchain]: https://github.com/exonum/exonum-java-binding/blob/master/exonum-java-binding-core/src/main/java/com/exonum/binding/blockchain/Blockchain.java
 [build-description]: https://github.com/exonum/exonum-java-binding/blob/master/exonum-java-binding-service-archetype/src/main/resources/archetype-resources/pom.xml
 [Exonum-services]: ../architecture/services.md
 [Guice]: https://github.com/google/guice/wiki/GettingStarted

--- a/src/get-started/java-binding.md
+++ b/src/get-started/java-binding.md
@@ -252,17 +252,17 @@ class. The following functionality is available:
 - `getBlockHashes: ListIndex<HashCode>`
   The list of all block hashes, indexed by the block height.
 - `getBlockTransactions: ProofListIndexProxy<HashCode>`
-  The proof list of transaction hashes committed in the block with given height
-  or ID.
+  The proof list of transaction hashes committed in the block with the given
+  height or ID.
 - `getTxMessages: MapIndex<HashCode, TransactionMessage>`
   The map of transaction messages identified by their SHA-256 hashes. Both
   committed and in-pool (not yet processed) transactions are returned.
 - `getTxResults: ProofMapIndexProxy<HashCode, TransactionResult>`
-  The map of transaction execution results identified by corresponding
+  The map of transaction execution results identified by the corresponding
   transaction SHA-256 hashes.
 - `getTxLocations: MapIndex<HashCode, TransactionLocation>`
   The map of transaction positions inside the blockchain identified by
-  corresponding transaction SHA-256 hashes.
+  the corresponding transaction SHA-256 hashes.
 - `getBlocks: MapIndex<HashCode, Block>`
   The map of block objects identified by corresponding block hashes.
 - `getLastBlock: Block`

--- a/src/get-started/java-binding.md
+++ b/src/get-started/java-binding.md
@@ -497,7 +497,8 @@ For using the library just include the dependency in your `pom.xml`:
 [abstractservice]: https://exonum.com/doc/api/java-binding-core/latest/com/exonum/binding/service/AbstractService.html
 [apicontrollertest]: https://github.com/exonum/exonum-java-binding/blob/v0.3/exonum-java-binding-cryptocurrency-demo/src/test/java/com/exonum/binding/cryptocurrency/ApiControllerTest.java
 [app-tutorial]: https://github.com/exonum/exonum-java-binding/blob/master/exonum-java-binding-core/rust/ejb-app/TUTORIAL.md
-<!-- TODO: change `blob` with `0.4` after the release OR insert a Javadoc link instead -->
+<!-- TODO: change `blob` with `0.4` after the release OR insert a Javadoc link
+  instead -->
 [blockchain]: https://github.com/exonum/exonum-java-binding/blob/master/exonum-java-binding-core/src/main/java/com/exonum/binding/blockchain/Blockchain.java
 [build-description]: https://github.com/exonum/exonum-java-binding/blob/master/exonum-java-binding-service-archetype/src/main/resources/archetype-resources/pom.xml
 [Exonum-services]: ../architecture/services.md

--- a/src/get-started/java-binding.md
+++ b/src/get-started/java-binding.md
@@ -244,26 +244,35 @@ processing on the node.
 
 ### Core Schema API
 
-Users can access blockchain state using methods of [`Blockchain`][blockchain] class. The following functionality is available:
+Users can access blockchain state using methods of [`Blockchain`][blockchain]
+class. The following functionality is available:
 
 - `getHeight: long`
   The height of the latest committed block in the blockchain.
 - `getBlockHashes: ListIndex<HashCode>`
   The list of all block hashes, indexed by the block height.
 - `getBlockTransactions: ProofListIndexProxy<HashCode>`
-  The proof list of transaction hashes committed in the block with given height or ID.
+  The proof list of transaction hashes committed in the block with given height
+  or ID.
 - `getTxMessages: MapIndex<HashCode, TransactionMessage>`
-  The map of transaction messages identified by their SHA-256 hashes. Both committed and in-pool (not yet processed) transactions are returned.
+  The map of transaction messages identified by their SHA-256 hashes. Both
+  committed and in-pool (not yet processed) transactions are returned.
 - `getTxResults: ProofMapIndexProxy<HashCode, TransactionResult>`
-  The map with a key-value pair of a transaction hash and execution result. It's also possible to get a `TransactionResult` of a single transaction by its hash.
+  The map with a key-value pair of a transaction hash and execution result.
+  It's also possible to get a `TransactionResult` of a single transaction by its
+  hash.
 - `getTxLocations: MapIndex<HashCode, TransactionLocation>`
-  Returns a map that keeps the transaction position inside the blockchain for every transaction hash. It's also possible to get a `TransactionLocation` of a single transaction by its hash.
+  Returns a map that keeps the transaction position inside the blockchain for
+  every transaction hash. It's also possible to get a `TransactionLocation` of
+  a single transaction by its hash.
 - `getBlocks: MapIndex<HashCode, Block>`
-  The map that stores a block object for every block hash.  It's also possible to get a single block object by its hash.
+  The map that stores a block object for every block hash.  It's also possible
+  to get a single block object by its hash.
 - `getLastBlock: Block`
   The latest committed block.
 - `getActualConfiguration: StoredConfiguration`
-  The configuration for the latest height of the blockchain, including services and their parameters.
+  The configuration for the latest height of the blockchain, including services
+  and their parameters.
 
 ### External Service API
 

--- a/src/get-started/java-binding.md
+++ b/src/get-started/java-binding.md
@@ -261,7 +261,7 @@ Users can access blockchain state using methods of [`Blockchain`][blockchain] cl
 - `getBlocks: MapIndex<HashCode, Block>`
   The map that stores a block object for every block hash.  It's also possible to get a single block object by its hash.
 - `getLastBlock: Block`
-  The latest commited block.
+  The latest committed block.
 - `getActualConfiguration: StoredConfiguration`
   The configuration for the latest height of the blockchain, including services and their parameters.
 

--- a/src/get-started/java-binding.md
+++ b/src/get-started/java-binding.md
@@ -258,7 +258,7 @@ class. The following functionality is available:
   The map of transaction messages identified by their SHA-256 hashes. Both
   committed and in-pool (not yet processed) transactions are returned.
 - `getTxResults: ProofMapIndexProxy<HashCode, TransactionResult>`
-  The map with of transaction execution results identified by corresponding
+  The map of transaction execution results identified by corresponding
   transaction SHA-256 hashes.
 - `getTxLocations: MapIndex<HashCode, TransactionLocation>`
   The map of transaction positions inside the blockchain identified by

--- a/src/get-started/java-binding.md
+++ b/src/get-started/java-binding.md
@@ -242,6 +242,29 @@ synchronous I/O in this handler, as it is invoked synchronously in the same
 thread that handles transactions. Blocking that thread will delay transaction
 processing on the node.
 
+### Core Schema API
+
+Users can access blockchain state using methods of [`Blockchain`][blockchain] class. The following functionality is available:
+
+- `getHeight: long`
+  The height of the latest committed block in the blockchain.
+- `getAllBlockHashes: ListIndex<HashCode>`
+  The list of all block hashes, indexed by the block height.
+- `getBlockTransactions: ProofListIndexProxy<HashCode>`
+  The proof list of transaction hashes committed in the block with given height or ID.
+- `getTxMessages: MapIndex<HashCode, TransactionMessage>`
+  The map of transaction messages identified by their SHA-256 hashes. Both committed and in-pool (not yet processed) transactions are returned.
+- `getTxResults: ProofMapIndexProxy<HashCode, TransactionResult>`
+  The map with a key-value pair of a transaction hash and execution result. It's also possible to get a `TransactionResult` of a single transaction by its hash.
+- `getTxLocations: MapIndex<HashCode, TransactionLocation>`
+  Returns a map that keeps the transaction position inside the blockchain for every transaction hash. It's also possible to get a `TransactionLocation` of a single transaction by its hash.
+- `getBlocks: MapIndex<HashCode, Block>`
+  The map that stores a block object for every block hash.  It's also possible to get a single block object by its hash.
+- `getLastBlock: Block`
+  The latest commited block.
+- `getActualConfiguration: StoredConfiguration`
+  The configuration for the latest height of the blockchain, including services and their parameters.
+
 ### External Service API
 
 The external service API is used for the interaction between the service and the
@@ -466,6 +489,7 @@ For using the library just include the dependency in your `pom.xml`:
 [abstractservice]: https://exonum.com/doc/api/java-binding-core/latest/com/exonum/binding/service/AbstractService.html
 [apicontrollertest]: https://github.com/exonum/exonum-java-binding/blob/v0.3/exonum-java-binding-cryptocurrency-demo/src/test/java/com/exonum/binding/cryptocurrency/ApiControllerTest.java
 [app-tutorial]: https://github.com/exonum/exonum-java-binding/blob/master/exonum-java-binding-core/rust/ejb-app/TUTORIAL.md
+[blockchain]: https://github.com/exonum/exonum-java-binding/0.4/master/exonum-java-binding-core/src/main/java/com/exonum/binding/blockchain/Blockchain.java
 [build-description]: https://github.com/exonum/exonum-java-binding/blob/master/exonum-java-binding-service-archetype/src/main/resources/archetype-resources/pom.xml
 [Exonum-services]: ../architecture/services.md
 [Guice]: https://github.com/google/guice/wiki/GettingStarted

--- a/src/get-started/java-binding.md
+++ b/src/get-started/java-binding.md
@@ -244,8 +244,10 @@ processing on the node.
 
 ### Core Schema API
 
-Users can access blockchain state using methods of [`Blockchain`][blockchain]
-class. The following functionality is available:
+Users can access information stored in the blockchain by the framework using
+methods of [`Blockchain`][blockchain] class. This API can be used both in
+transaction code and in read requests. The following functionality is
+available:
 
 - `getHeight: long`
   The height of the latest committed block in the blockchain.

--- a/src/get-started/java-binding.md
+++ b/src/get-started/java-binding.md
@@ -248,7 +248,7 @@ Users can access blockchain state using methods of [`Blockchain`][blockchain] cl
 
 - `getHeight: long`
   The height of the latest committed block in the blockchain.
-- `getAllBlockHashes: ListIndex<HashCode>`
+- `getBlockHashes: ListIndex<HashCode>`
   The list of all block hashes, indexed by the block height.
 - `getBlockTransactions: ProofListIndexProxy<HashCode>`
   The proof list of transaction hashes committed in the block with given height or ID.

--- a/src/get-started/java-binding.md
+++ b/src/get-started/java-binding.md
@@ -266,7 +266,7 @@ available:
   The map of transaction positions inside the blockchain identified by
   the corresponding transaction SHA-256 hashes.
 - `getBlocks: MapIndex<HashCode, Block>`
-  The map of block objects identified by corresponding block hashes.
+  The map of block objects identified by the corresponding block hashes.
 - `getLastBlock: Block`
   The latest committed block.
 - `getActualConfiguration: StoredConfiguration`


### PR DESCRIPTION
Add Core Schema API section to EJB User Guide.