### PR TITLE
Fixed Jenkins build issue

### DIFF
--- a/versioned.js
+++ b/versioned.js
@@ -26,7 +26,7 @@ const generateVersionedDocs = async (versions) => {
   const returnToBranch = await git.getBranchName()
   
   if (BUILD_ENVIRONMENT === 'jenkins') {
-    returnToBranch == 'master'
+    returnToBranch = 'master'
   }
 
   fs.mkdirSync('./version')

--- a/versioned.js
+++ b/versioned.js
@@ -24,7 +24,7 @@ const generateVersionedDocs = async (versions) => {
 
   const git = new Git({})
   let returnToBranch = await git.getBranchName()
-  
+
   if (BUILD_ENVIRONMENT === 'jenkins') {
     returnToBranch = 'master'
   }

--- a/versioned.js
+++ b/versioned.js
@@ -23,7 +23,7 @@ const generateVersionedDocs = async (versions) => {
   await cleanUp()
 
   const git = new Git({})
-  const returnToBranch = await git.getBranchName()
+  let returnToBranch = await git.getBranchName()
   
   if (BUILD_ENVIRONMENT === 'jenkins') {
     returnToBranch = 'master'

--- a/versioned.js
+++ b/versioned.js
@@ -23,9 +23,10 @@ const generateVersionedDocs = async (versions) => {
   await cleanUp()
 
   const git = new Git({})
+  const returnToBranch = await git.getBranchName()
   
-  if (BUILD_ENVIRONMENT != 'jenkins') {
-    const returnToBranch = await git.getBranchName()
+  if (BUILD_ENVIRONMENT === 'jenkins') {
+    returnToBranch == 'master'
   }
 
   fs.mkdirSync('./version')
@@ -45,9 +46,7 @@ const generateVersionedDocs = async (versions) => {
     versionedMkdocs.extra.versions = extraVersions
     fs.writeFileSync(`./version/${version}.yml`, YAML.stringify(versionedMkdocs, 7), 'utf8')
     await mkdocsBuild(`./version/${version}`, configFile)
-    if (BUILD_ENVIRONMENT != 'jenkins') {
-      await git.checkout(returnToBranch)
-    }
+    await git.checkout(returnToBranch)
   }
 
   return { failed, success: versions.length - failed }


### PR DESCRIPTION
Investigation shown that Jenkins checks out to master in the form of `git checkout -f <commit_id>`, therefore git.getBranchName() returns string which doesn't contain branch name and looks something like `(HEAD detached at 5cc110e)`. This is why the script fails during the git.checkout(returnToBranch) call.
Now it checks for environment variable BUILD_ENVIRONMENT and if it set to 'jenkins' the script assumes that it is running in the automated environment and doesn't perform branch preservation.