### PR TITLE
Add EJB time oracle documentation [ECR-2896]

### DIFF
--- a/src/advanced/time.md
+++ b/src/advanced/time.md
@@ -3,9 +3,8 @@
 <!-- cspell:ignore tlsdate,roughtime -->
 
 Time Oracle allows user services to access the calendar time supplied by
-validator nodes to the blockchain.
-
-Time Oracle is available in [Rust][exonum-time] and [Java][java-time-oracle].
+validator nodes to the blockchain. Its implementations for Exonum are available
+in [Rust][exonum-time] and [Java][java-time-oracle].
 
 ## The Problem
 

--- a/src/advanced/time.md
+++ b/src/advanced/time.md
@@ -7,7 +7,7 @@ This service allows determining time,
 importing it from the external world to the blockchain
 and keeping its current value in the blockchain.
 
-Time Oracle is supported in [Java][java-time-oracle] as well.
+Time Oracle is available in [Rust][exonum-time] and [Java][java-time-oracle].
 
 ## The Problem
 

--- a/src/advanced/time.md
+++ b/src/advanced/time.md
@@ -2,10 +2,8 @@
 
 <!-- cspell:ignore tlsdate,roughtime -->
 
-[**exonum-time**][exonum-time] is a time oracle service for Exonum.
-This service allows determining time,
-importing it from the external world to the blockchain
-and keeping its current value in the blockchain.
+Time Oracle allows user services to access the calendar time supplied by
+validator nodes to the blockchain.
 
 Time Oracle is available in [Rust][exonum-time] and [Java][java-time-oracle].
 

--- a/src/advanced/time.md
+++ b/src/advanced/time.md
@@ -7,6 +7,8 @@ This service allows determining time,
 importing it from the external world to the blockchain
 and keeping its current value in the blockchain.
 
+Time Oracle is supported in [Java][java-time-oracle] as well.
+
 ## The Problem
 
 Implementing the business logic of many practical blockchain solutions requires
@@ -268,11 +270,8 @@ the tight integration with consensus. This approach is more flexible and
 manageable, and could be generalized to the agreement between arbitrary
 collectively trusted entities, which may behave maliciously.
 
-## Other languages support
-
-- [Java Time Oracle](https://github.com/exonum/exonum-java-binding/tree/master/exonum-java-binding/time-oracle)
-
 [exonum-time]: https://github.com/exonum/exonum/tree/master/services/time
+[java-time-oracle]: https://github.com/exonum/exonum-java-binding/tree/master/exonum-java-binding/time-oracle
 [tlsdate]: https://github.com/ioerror/tlsdate
 [roughtime]: https://roughtime.googlesource.com/roughtime
 [ISO8601]: https://en.wikipedia.org/wiki/ISO_8601

--- a/src/advanced/time.md
+++ b/src/advanced/time.md
@@ -268,6 +268,10 @@ the tight integration with consensus. This approach is more flexible and
 manageable, and could be generalized to the agreement between arbitrary
 collectively trusted entities, which may behave maliciously.
 
+## Other languages support
+
+* [Java Time Oracle](https://github.com/exonum/exonum-java-binding/tree/master/exonum-java-binding/time-oracle)
+
 [exonum-time]: https://github.com/exonum/exonum/tree/master/services/time
 [tlsdate]: https://github.com/ioerror/tlsdate
 [roughtime]: https://roughtime.googlesource.com/roughtime

--- a/src/advanced/time.md
+++ b/src/advanced/time.md
@@ -270,7 +270,7 @@ collectively trusted entities, which may behave maliciously.
 
 ## Other languages support
 
-* [Java Time Oracle](https://github.com/exonum/exonum-java-binding/tree/master/exonum-java-binding/time-oracle)
+- [Java Time Oracle](https://github.com/exonum/exonum-java-binding/tree/master/exonum-java-binding/time-oracle)
 
 [exonum-time]: https://github.com/exonum/exonum/tree/master/services/time
 [tlsdate]: https://github.com/ioerror/tlsdate

--- a/src/get-started/java-binding.md
+++ b/src/get-started/java-binding.md
@@ -504,11 +504,10 @@ Currently Java Binding includes the following built-in services:
   article for more details.
 
 - **Time Oracle.**
-  Time oracle allows determining time, importing it from the external world to
-  the blockchain and keeping its current value in the blockchain.
+  Time oracle allows user services access the calendar time supplied by
+  validator nodes to the blockchain.
 
-  See the [*Time Oracle*](../advanced/time.md)
-  article for more details.
+  See the [*Time Oracle*](../advanced/time.md) article for more details.
 
 To enable a particular service, include its name in `ejb_app_services.toml`
 configuration file in the EJB App's directory with the following content:

--- a/src/get-started/java-binding.md
+++ b/src/get-started/java-binding.md
@@ -503,6 +503,13 @@ Currently Java Binding includes the following built-in services:
   See the [*Anchoring Service*](../advanced/bitcoin-anchoring.md)
   article for more details.
 
+- **Time Oracle.**
+  Time oracle allows determining time, importing it from the external world to
+  the blockchain and keeping its current value in the blockchain.
+
+  See the [*Time Oracle*](../advanced/time.md)
+  article for more details.
+
 To enable a particular service, include its name in `ejb_app_services.toml`
 configuration file in the EJB App's directory with the following content:
 
@@ -514,6 +521,7 @@ where possible values for `service-name` are:
 
 - `configuration` for Configuration Update Service.
 - `btc-anchoring` for Anchoring Service.
+- `time` for Time Oracle.
 
 In case there is no `ejb_app_services.toml` file, only Configuration Service will
 be activated.
@@ -543,8 +551,6 @@ For using the library just include the dependency in your `pom.xml`:
   service data (collections and their elements) are available only in a "raw"
   form – without deserialization of the content, which makes their use somewhat
   difficult.
-- [Time oracle](../advanced/time.md) service is not available,
-  but will be integrated into EJB App soon.
 - Custom Rust services can be added to the application only by modifying and
   rebuilding thereof.
 - The application supports only one Java service. Support of multiple Java

--- a/src/get-started/java-binding.md
+++ b/src/get-started/java-binding.md
@@ -504,7 +504,7 @@ Currently Java Binding includes the following built-in services:
   article for more details.
 
 - **Time Oracle.**
-  Time oracle allows user services access the calendar time supplied by
+  Time oracle allows user services to access the calendar time supplied by
   validator nodes to the blockchain.
 
   See the [*Time Oracle*](../advanced/time.md) article for more details.


### PR DESCRIPTION
Update EJB time oracle documentation.
https://github.com/exonum/exonum-java-binding/tree/master/exonum-java-binding/time-oracle link is not yet valid, but will be after https://github.com/exonum/exonum-java-binding/pull/754 is merged.