### PR TITLE
Add info about installing librocksdb from our PPA [ECR-3040]

### DIFF
--- a/src/get-started/install.md
+++ b/src/get-started/install.md
@@ -44,8 +44,9 @@ For distributives with `deb`-based package managers (such as Debian or Ubuntu),
 use
 
 ```shell
+add-apt-repository ppa:exonum/rocksdb
 apt-get install build-essential libsodium-dev libsnappy-dev \
-    pkg-config libprotobuf-dev protobuf-compiler
+    librocksdb5.17 pkg-config libprotobuf-dev protobuf-compiler
 ```
 
 For `protobuf` installation add the following dependencies:
@@ -53,17 +54,6 @@ For `protobuf` installation add the following dependencies:
 ```shell
 add-apt-repository ppa:maarten-fonville/protobuf
 apt install libprotobuf-dev protobuf-compiler
-```
-
-!!! note
-    Exonum is tested with RocksDB version 5.17, which is not available in some
-    repositories (e.g. Ubuntu 16.04).
-
-To install recommended version of RocksDB, you may use a PPA prepared by Exonum team:
-
-```shell
-add-apt-repository ppa:exonum/rocksdb
-apt install librocksdb5.17
 ```
 
 Package names and installation methods may differ in other Linux distributives;

--- a/src/get-started/install.md
+++ b/src/get-started/install.md
@@ -45,7 +45,7 @@ use
 
 ```shell
 apt-get install build-essential libsodium-dev libsnappy-dev \
-    librocksdb-dev pkg-config libprotobuf-dev protobuf-compiler
+    pkg-config libprotobuf-dev protobuf-compiler
 ```
 
 For `protobuf` installation add the following dependencies:
@@ -53,6 +53,17 @@ For `protobuf` installation add the following dependencies:
 ```shell
 add-apt-repository ppa:maarten-fonville/protobuf
 apt install libprotobuf-dev protobuf-compiler
+```
+
+!!! note
+    Exonum is tested with RocksDB version 5.17, which is not available in some
+    repositories (e.g. Ubuntu 16.04).
+    
+To install recommended version of RocksDB, you may use a PPA prepared by Exonum team:
+
+```shell
+add-apt-repository ppa:exonum/rocksdb
+apt install librocksdb5.17
 ```
 
 Package names and installation methods may differ in other Linux distributives;

--- a/src/get-started/install.md
+++ b/src/get-started/install.md
@@ -58,7 +58,7 @@ apt install libprotobuf-dev protobuf-compiler
 !!! note
     Exonum is tested with RocksDB version 5.17, which is not available in some
     repositories (e.g. Ubuntu 16.04).
-    
+
 To install recommended version of RocksDB, you may use a PPA prepared by Exonum team:
 
 ```shell


### PR DESCRIPTION
On some old Ubuntu versions RocksDB shows unpredictable behavior for EJB, and all our CI is done using RocksDB 5.17. To avoid bugs, we should mention this fact in the docs.

<!--
Please target the following branch:
- `master` if your pull request fixes bugs in the documentation, describes
  released features, etc. In other words,
  a pull request targeting `master` should be possible to merge and
  push to https://exonum.com/doc/ at any time.
- `develop` if your pull request describes features introduced into an upcoming
  version of Exonum. A request targeting `develop` should be pushed to
  https://exonum.com/doc/ no earlier than this upcoming version is released.
  If your documentation update has its own feature-branch,
  e.g., `develop-ejb-1.1`, please target that one.
-->
