### PR TITLE
Fix invalid letter in choko install command

### DIFF
--- a/src/get-started/install.md
+++ b/src/get-started/install.md
@@ -79,7 +79,7 @@ Install the latest version of the following packages:
 Use package manager [Chocolatey][chocolatey] to install Protobuf:
 
 ```shell
-choco install -y protoс
+choco install -y protoc
 ```
 
 ## Adding Environment Variables


### PR DESCRIPTION
Here used to be a russian 'с' letter
<!--
Please target the following branch:
- `master` if your pull request fixes bugs in the documentation, describes
  released features, etc. In other words,
  a pull request targeting `master` should be possible to merge and
  push to https://exonum.com/doc/ at any time.
- `develop` if your pull request describes features introduced into an upcoming
  version of Exonum. A request targeting `develop` should be pushed to
  https://exonum.com/doc/ no earlier than this upcoming version is released.
  If your documentation update has its own feature-branch,
  e.g., `develop-ejb-1.1`, please target that one.
-->
