### PR TITLE
Require rocksdb (temporarily) [ECR-3169]

### DIFF
--- a/src/get-started/java-binding.md
+++ b/src/get-started/java-binding.md
@@ -23,7 +23,7 @@ Follow these steps:
   For Mac OS, you can use [Homebrew][brew-install] as follows:
 
   ```bash
-  brew install libsodium
+  brew install libsodium rocksdb
   ```
 
 - Download and unpack the archive from the [Releases page][github-releases]


### PR DESCRIPTION

It has been discovered that the packaging
procedure does not produce RocksDB-independent
binary (java_bindings library), hence the app users
must install RocksDB on macOS.