### PR TITLE
Remove rocksdb from requirements as it will be linked statically. [ECR-3324]

### DIFF
--- a/src/get-started/java-binding.md
+++ b/src/get-started/java-binding.md
@@ -31,8 +31,7 @@ deployment.
   ```
 
 - Install [Libsodium][libsodium] as the necessary runtime dependency.
-  For Mac OS also install RocksDB library:
-  
+
 ??? example "Linux (Ubuntu)"
     ```bash
     sudo apt-get update && sudo apt-get install libsodium-dev
@@ -40,7 +39,7 @@ deployment.
   
 ??? example "Mac OS"
     ```bash
-    brew install libsodium rocksdb
+    brew install libsodium
     ```
 
 - Follow the steps in the [After Install](#after-install) section below


### PR DESCRIPTION
Starting from release 0.7.0 we will link RocksDB statically on Mac.
