### PR TITLE
Fix invalid ROCKSDB_LIB_DIR in installation guide

### DIFF
--- a/src/get-started/install.md
+++ b/src/get-started/install.md
@@ -100,7 +100,7 @@ export SNAPPY_LIB_DIR=/usr/local/lib
 ### Linux
 
 ```shell
-export ROCKSDB_LIB_DIR=/usr/lib/x86_64-linux-gnu
+export ROCKSDB_LIB_DIR=/usr/lib
 export SNAPPY_LIB_DIR=/usr/lib/x86_64-linux-gnu
 ```
 


### PR DESCRIPTION
The installation instruction is invalid. Our package `librocksdb5.17` from Exonum PPA installs library files into `/usr/lib`, not into `/usr/lib/x86_64-linux-gnu`. So with current instructions RocksDB is always compiled from sources. Valid `ROCKSDB_LIB_DIR` is also used in our Travis configuration: https://github.com/exonum/exonum/blob/master/.travis.yml#L59

Spotted when testing EJB on Linux by @dip56 