### PR TITLE
Correct value of the `end` field [ECR-3187]

### DIFF
--- a/src/advanced/node-management.md
+++ b/src/advanced/node-management.md
@@ -752,8 +752,8 @@ The JSON object of the explored block range `range` and the array `blocks` of
 the `BlockHeader` objects. The range defines its largest and the smallest
 heights of blocks. The amount of collected blocks from the traversed range
 should not exceed `count` value.
-The largest height `end` equals to `latest + 1` if provided or to the height of
-the latest block in the blockchain, the smallest height `start` takes values
+The largest height `end` equals to `latest + 1`, the smallest height `start`
+takes values
 in `0..latest - count + 1`. Blocks in the array are sorted in the descending
 order
 according to their heights. Height of any block in the array is greater than or


### PR DESCRIPTION
Correct the meaning of the `end` field of the response for the "Blocks in Range" endpoint.
https://jira.bf.local/browse/ECR-3187