### PR TITLE
Use correct rocksdb package in installation instructions

### DIFF
--- a/src/get-started/install.md
+++ b/src/get-started/install.md
@@ -45,8 +45,9 @@ use
 
 ```shell
 add-apt-repository ppa:exonum/rocksdb
+apt-get update
 apt-get install build-essential libsodium-dev libsnappy-dev libssl-dev \
-    librocksdb5.17 pkg-config clang-7 lldb-7 lld-7
+    librocksdb6.2 pkg-config clang-7 lldb-7 lld-7
 ```
 
 For `protobuf` installation add the following dependencies:


### PR DESCRIPTION
Exonum now uses RocksDB 6.2, not 5.17. Using correct package is important when building EJB App from sources.