### PR TITLE
Clarify that Exonum Java uses a separate port [ECR-3856]

### DIFF
--- a/src/get-started/java-binding.md
+++ b/src/get-started/java-binding.md
@@ -493,6 +493,11 @@ at `/api/services/cryptocurrency/balance/:walletId`.
 See [documentation][vertx-web-docs] on the possibilities of `Vert.x` used as a web
 framework.
 
+!!! note
+    Exonum Java uses separate port for the external service API. It is used for
+    Java services only. Exonum and Rust endpoints are accessible via different
+    port that is configured separately.
+
 ### Configuration
 
 #### Initialization and Initial Configuration
@@ -1175,7 +1180,8 @@ There are several required parameters here:
 - `--artifacts-path` for a path to the directory with the compiled service
   artifacts.
 - `--ejb-port` for a port that Java services will use for communication.
-  Java Binding does not use the public API address directly.
+  Java Binding does not use the public API address directly. Only Java services
+  are accessible via this port.
 - `--public-api-address` and `--private-api-address` for the socket addresses
   for the node user API. The public API address is used by users to send
   transactions and requests to the blockchain, the private one is used by node

--- a/src/get-started/java-binding.md
+++ b/src/get-started/java-binding.md
@@ -494,9 +494,10 @@ See [documentation][vertx-web-docs] on the possibilities of `Vert.x` used as a w
 framework.
 
 !!! note
-    Exonum Java uses separate port for the external service API. It is used for
-    Java services only. Exonum and Rust endpoints are accessible via different
-    port that is configured separately.
+    Java services use a _separate_ server from Rust services.
+    The TCP ports of Java and Rust servers are specified
+    when a node is started, see [«Running the node»](#running-the-node)
+    section for details.
 
 ### Configuration
 


### PR DESCRIPTION
<!--
Please target the following branch:
- `master` if your pull request fixes bugs in the documentation, describes
  released features, etc. In other words,
  a pull request targeting `master` should be possible to merge and
  push to https://exonum.com/doc/ at any time.
- `develop` if your pull request describes features introduced into an upcoming
  version of Exonum. A request targeting `develop` should be pushed to
  https://exonum.com/doc/ no earlier than this upcoming version is released.
  If your documentation update has its own feature-branch,
  e.g., `develop-ejb-1.1`, please target that one.
-->
