### PR TITLE
Update light client tutorial [ECR-4179]

### DIFF
--- a/src/get-started/light-client.md
+++ b/src/get-started/light-client.md
@@ -40,7 +40,7 @@ stages:
 3. Define transaction type
 4. Define transaction payload
 5. Sign the transaction
-6. Send transaction to the blockchain.
+6. Send the transaction to the blockchain.
 
 Exonum light client uses Protobuf as the data serialization
 format. This is enabled by the [`protobufjs`][protobufjs-lib] library.

--- a/src/get-started/light-client.md
+++ b/src/get-started/light-client.md
@@ -15,8 +15,9 @@ Below we will provide you with the detailed description of how said
 functionality is executed in Exonum light client.
 
 !!! note
-    Light client is also available in Java language.
-    Please refer to its [readme][lc-java] for details.
+    Light clients are also available in other languages:
+    [Java][lc-java] and [Python][lc-python]. See their readmes
+    for more details.
 
 ## Before You Start
 
@@ -486,3 +487,4 @@ support!
 [cryptocurrency-advanced]: https://github.com/exonum/exonum/tree/master/examples/cryptocurrency-advanced/frontend
 [timestamping]: https://github.com/exonum/exonum/tree/master/examples/timestamping/frontend
 [lc-java]: https://github.com/exonum/exonum-java-binding/tree/master/exonum-light-client
+[lc-python]: https://github.com/exonum/exonum-python-client

--- a/src/get-started/light-client.md
+++ b/src/get-started/light-client.md
@@ -114,7 +114,7 @@ Here:
 Define `Transfer` transaction schema and its fields:
 
 ```javascript
-import * as proto from 'stubs.js'
+import * as proto from './stubs'
 const { cryptocurrency_advanced } = proto.exonum.examples
 
 // Numeric identifier of the cryptocurrency service
@@ -135,6 +135,12 @@ during [service instantiation](../architecture/service-lifecycle.md);
 you can find it out via an endpoint in
 the [system API plugin](../advanced/other-services.md#system-api).
 Method identifiers are specified in the [service interface](../glossary.md#interface).
+
+!!! note
+    As of Exonum 1.0, service interfaces do not have a language-independent form,
+    so there is no easy way to get correspondence between method IDs
+    and Protobuf messages. Implementing an [IDL] for interfaces
+    is in the [project roadmap](../roadmap.md#finalizing-service-interfaces).
 
 ### Specify Transaction Payload
 
@@ -494,3 +500,4 @@ support!
 [timestamping]: https://github.com/exonum/exonum/tree/master/examples/timestamping/frontend
 [lc-java]: https://github.com/exonum/exonum-java-binding/tree/master/exonum-light-client
 [lc-python]: https://github.com/exonum/exonum-python-client
+[IDL]: https://en.wikipedia.org/wiki/Interface_description_language

--- a/src/get-started/light-client.md
+++ b/src/get-started/light-client.md
@@ -119,11 +119,13 @@ const { cryptocurrency_advanced } = proto.exonum.examples
 
 // Numeric identifier of the cryptocurrency service
 const SERVICE_ID = 101
+// Numeric ID of the `Transfer` transaction within the service
+const TRANSFER_ID = 0
 
 const Transfer = new exonum.Transaction({
    schema: cryptocurrency_advanced.Transfer,
    serviceId: SERVICE_ID,
-   methodId: 1,
+   methodId: TRANSFER_ID,
 })
 ```
 
@@ -241,7 +243,7 @@ In this case, the transaction type will be specified as
 const Transfer = new exonum.Transaction({
   schema: TransferSchema,
   serviceId: SERVICE_ID,
-  methodId: 1,
+  methodId: TRANSFER_ID,
 })
 ```
 
@@ -311,7 +313,7 @@ according to the downloaded set of keys of the validators:
 const { block } = data.block_proof
 try {
   // Will throw if an error during verification occurs
-  exonum.verifyBlock(block, validatorKeys))
+  exonum.verifyBlock(block, validatorKeys)
 } catch(e) {
   console.error(e)
 }
@@ -457,7 +459,7 @@ definition of only one transaction type, `Transfer`.
 const Transfer = new exonum.Transaction({
   schema: cryptocurrency_advanced.Transfer,
   serviceId: SERVICE_ID,
-  methodId: 1,
+  methodId: TRANSFER_ID,
 })
 
 let index = 0

--- a/src/get-started/light-client.md
+++ b/src/get-started/light-client.md
@@ -416,8 +416,12 @@ const verifiedTransactions = new exonum.ListProof(
   exonum.Hash,
 )
 
+// Convert the history hash from the Protobuf-compatible format
+// returned by the endpoint, to a hex string.
+let expectedHash = new Uint8Array(wallet.history_hash.data)
+expectedHash = exonum.uint8ArrayToHexadecimal(expectedHash)
 // Check that the proof is tied to the previous level.
-if (verifiedTransactions.merkleRoot !== wallet.history_hash) {
+if (verifiedTransactions.merkleRoot !== expectedHash) {
   throw new Error('Transactions proof is corrupted')
 }
 ```

--- a/src/get-started/light-client.md
+++ b/src/get-started/light-client.md
@@ -2,7 +2,7 @@
 
 In this tutorial we describe how to use the light client to interact with
 Exonum services. The tutorial extends the
-[*Cryptocurrency Advanced*](data-proofs.md) tutorial.
+[Advanced Cryptocurrency](data-proofs.md) tutorial.
 
 Light client is a JavaScript library used for a number of purposes:
 
@@ -16,7 +16,7 @@ functionality is executed in Exonum light client.
 
 !!! note
     Light clients are also available in other languages:
-    [Java][lc-java] and [Python][lc-python]. See their readmes
+    [Java][lc-java] and [Python][lc-python]. See their readme files
     for more details.
 
 ## Before You Start
@@ -59,7 +59,7 @@ reflection:
 
 Below we provide a complete workflow of transaction execution
 based on the transfer transaction from
-the [*Advanced Cryptocurrency Tutorial*][cryptocurrency-advanced].
+the [Advanced Cryptocurrency][cryptocurrency-advanced] tutorial.
 
 ### Define Transaction Schema
 
@@ -90,6 +90,7 @@ As the `.proto` file is ready, generate the JavaScript module as follows:
 ```sh
 pbjs --keep-case \
   --target static-module \
+  --root cryptocurrency \
   --path node_modules/exonum-client/proto \
   example.proto \
   --out ./proto.js
@@ -100,6 +101,9 @@ Here:
 - `--keep-case` opts out of transforming field names
 - `--target` specifies the output type (in our case, we want a standalone
   JS module)
+- `--root` specifies a namespace for the generated types. Without this
+  option, the types may clash with the Protobuf types used by
+  the light client library, which will lead to errors
 - `--path` adds a directory to the include path (we specify a path
   to the Protobuf declarations bundled with the client library)
 - `example.proto` specifies an input file

--- a/src/get-started/light-client.md
+++ b/src/get-started/light-client.md
@@ -239,9 +239,9 @@ In this case, the transaction type will be specified as
 
 ```javascript
 const Transfer = new exonum.Transaction({
-   schema: TransferSchema,
-   serviceId: SERVICE_ID,
-   methodId: 1,
+  schema: TransferSchema,
+  serviceId: SERVICE_ID,
+  methodId: 1,
 })
 ```
 
@@ -455,9 +455,9 @@ definition of only one transaction type, `Transfer`.
 ```javascript
 // Transfer transaction definition (same as previously)
 const Transfer = new exonum.Transaction({
-   schema: cryptocurrency_advanced.Transfer,
-   serviceId: SERVICE_ID,
-   methodId: 1,
+  schema: cryptocurrency_advanced.Transfer,
+  serviceId: SERVICE_ID,
+  methodId: 1,
 })
 
 let index = 0
@@ -471,7 +471,7 @@ for (let transaction of data.wallet_history.transactions) {
   // corresponding hash in the array of transaction hashes.
   const expectedHash = verifiedTransactions.entries[index++]
   if (parsed.hash() !== expectedHash) {
-     throw new Error('Invalid transaction hash')
+    throw new Error('Invalid transaction hash')
   }
 }
 ```


### PR DESCRIPTION
This PR updates the light client tutorial and removes links to the timestamping tutorial (which will be removed). The tutorial is slightly sketchy; it's based not on the actual code, but on my assumptions on how it should be written.

-----

See: https://jira.bf.local/browse/ECR-4179