### PR TITLE
Add Java code examples [ECR-4250]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ npm-debug.log
 # Generated docs
 site/
 version/
+
+# 3rd-party Python eggs installed in 'edit' mode
+3rd-party/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "exonum-java-binding"]
+	path = src/code-examples/java
+	url = https://github.com/exonum/exonum-java-binding.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "exonum-java-binding"]
-	path = src/code-examples/java
+	path = code-examples/java
 	url = https://github.com/exonum/exonum-java-binding.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ jobs:
             export REQUIREMENTS_FILE=requirements.txt
           fi
       install:
-        - pip install -r "$REQUIREMENTS_FILE" -r dev-requirements.txt
+        - pip install -r "$REQUIREMENTS_FILE" -r dev-requirements.txt --src 3rd-party
         - nvm install 12 && nvm use 12
         - npm install
         - python -m mkdocs --version
@@ -51,7 +51,7 @@ jobs:
       after_script:
         # Kill mkdocs server if it's still running
         - bash ./misc/lint.sh kill
-    
+
     # Since external link checks may fail because of rate limits, unreliable
     # connection etc., we allow this job to fail.
     - name: external links

--- a/README.md
+++ b/README.md
@@ -99,6 +99,14 @@ npm install
 
 (you will need Node 8+ installed).
 
+<!-- Todo: More appropriate place? -->
+
+Finally, initialize the Git submodules:
+
+```
+git submodule update --init --recursive
+```
+
 ### Viewing Documents Locally
 
 In order to run a local web server serving docs, use:

--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ You can read about Markdown [here](https://guides.github.com/features/mastering-
 or [other](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet)
 [places](http://www.mkdocs.org/user-guide/writing-your-docs/).
 
+Code examples are included from source using 
+[`mkdocs-codeinclude-plugin`][codeinclude-plugin] to ensure they are
+always up-to-date and correct.
+
+<!-- todo: Replace the link to our fork with the upstream link once our PRs are integrated. -->
+[codeinclude-plugin]: https://github.com/exonum/mkdocs-codeinclude-plugin/tree/develop#usage 
+
 ## Contributing
 
 In order to contribute, fork this repository, make some changes, and then submit
@@ -74,6 +81,14 @@ It is a good idea to preview your changes locally before sending a pull request.
 
 ### Installation
 
+Fetch and initialize the repository:
+
+```
+git clone https://github.com/exonum/exonum-doc
+cd exonum-doc
+git submodule update --init --recursive
+```
+
 First, you need to install [Python](http://python.org/) and [python-pip](https://pip.readthedocs.io/en/stable/installing/).
 Then, install the `mkdocs` theme together with its dependencies:
 
@@ -98,14 +113,6 @@ npm install
 ```
 
 (you will need Node 8+ installed).
-
-<!-- Todo: More appropriate place? -->
-
-Finally, initialize the Git submodules:
-
-```
-git submodule update --init --recursive
-```
 
 ### Viewing Documents Locally
 

--- a/README.md
+++ b/README.md
@@ -93,8 +93,9 @@ git submodule update --init --recursive
 First, you need to install [Python](http://python.org/) and [python-pip](https://pip.readthedocs.io/en/stable/installing/).
 Then, install the `mkdocs` theme together with its dependencies:
 
+<!-- Remove 3rd-party in ECR-4265 -->
 ```
-pip install -r requirements.txt
+pip install -r requirements.txt --src 3rd-party
 ```
 
 You may use [`requirements.lock`](requirements.lock) instead of [`requirements.txt`](requirements.txt)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ Code examples are included from source using
 [`mkdocs-codeinclude-plugin`][codeinclude-plugin] to ensure they are
 always up-to-date and correct.
 
-<!-- todo: Replace the link to our fork with the upstream link once our PRs are integrated. -->
+<!-- todo: Replace the link to our fork with the upstream link once our PRs
+       are integrated: https://github.com/rnorth/mkdocs-codeinclude-plugin/pulls -->
 [codeinclude-plugin]: https://github.com/exonum/mkdocs-codeinclude-plugin/tree/develop#usage 
 
 ## Contributing

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,7 +95,7 @@ nav:
     # Supervisor service documentation
     - 'Supervisor': 'advanced/supervisor.md'
     # Anchoring service documentation with Segwit
-    - 'Bitcoin Anchoring': 'advanced/bitcoin-anchoring.md'    
+    - 'Bitcoin Anchoring': 'advanced/bitcoin-anchoring.md'
     # Time service
     - 'Time Oracle': 'advanced/time.md'
     # Other useful services

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,9 @@ theme:
     primary: 'light green'
     accent: 'lime'
 
+plugins:
+  - codeinclude
+
 extra_css:
   - assets/stylesheets/extra.css
 extra_javascript:

--- a/package-lock.json
+++ b/package-lock.json
@@ -676,9 +676,9 @@
       }
     },
     "git-interface": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/git-interface/-/git-interface-2.0.4.tgz",
-      "integrity": "sha512-uXCM5qn/4qzOS9W4hiud4MJClbLbCPET0HKPl29a28yYd7rgwmdlV9eSIP7YDKblLCJavwUj/wZ8TVcdjd93KA==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/git-interface/-/git-interface-2.0.5.tgz",
+      "integrity": "sha512-Ydb3DAT+HaMsGsUyZnEHTwN6y8f7k/kWoRg/JUf+AH6t9jcdxP41H8b+jZrNASFIXf14eKVb9ej5wM8s/XTlyw==",
       "dev": true
     },
     "github-slugger": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "devDependencies": {
     "cspell": "^2.1.1",
     "fs-extra": "^8.1.0",
-    "git-interface": "^2.0.4",
+    "git-interface": "^2.0.5",
     "markdownlint-cli": "^0.16.0",
     "remark-cli": "^7.0.1",
     "remark-lint-no-dead-urls": "^1.0.1",

--- a/requirements.lock
+++ b/requirements.lock
@@ -4,6 +4,7 @@ mkdocs==1.0.4
 Pygments==2.5.2
 pygments-github-lexers==0.0.5
 mkdocs-material==4.6.0
+-e git+https://github.com/exonum/mkdocs-codeinclude-plugin@82454308b085ad2e4488da5c28448434ea190c34#egg=mkdocs_codeinclude_plugin
 ## The following requirements were added by pip freeze:
 Click==7.0
 htmlmin==0.1.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ mkdocs~=1.0
 Jinja2~=2.11
 Pygments~=2.5
 pygments-github-lexers~=0.0.5
--e git+https://github.com/exonum/mkdocs-codeinclude-plugin@f47e4462#egg=mkdocs_codeinclude_plugin
+-e git+https://github.com/exonum/mkdocs-codeinclude-plugin@7f4e3b16#egg=mkdocs_codeinclude_plugin

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ mkdocs~=1.0
 Jinja2~=2.11
 Pygments~=2.5
 pygments-github-lexers~=0.0.5
+-e git+https://github.com/exonum/mkdocs-codeinclude-plugin@99417fda#egg=mkdocs_codeinclude_plugin

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ mkdocs~=1.0
 Jinja2~=2.11
 Pygments~=2.5
 pygments-github-lexers~=0.0.5
--e git+https://github.com/exonum/mkdocs-codeinclude-plugin@99417fda#egg=mkdocs_codeinclude_plugin
+-e git+https://github.com/exonum/mkdocs-codeinclude-plugin@02e811ff#egg=mkdocs_codeinclude_plugin

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ mkdocs~=1.0
 Jinja2~=2.11
 Pygments~=2.5
 pygments-github-lexers~=0.0.5
--e git+https://github.com/exonum/mkdocs-codeinclude-plugin@7f4e3b16#egg=mkdocs_codeinclude_plugin
+-e git+https://github.com/exonum/mkdocs-codeinclude-plugin@82454308#egg=mkdocs_codeinclude_plugin

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ mkdocs~=1.0
 Jinja2~=2.11
 Pygments~=2.5
 pygments-github-lexers~=0.0.5
--e git+https://github.com/exonum/mkdocs-codeinclude-plugin@02e811ff#egg=mkdocs_codeinclude_plugin
+-e git+https://github.com/exonum/mkdocs-codeinclude-plugin@f47e4462#egg=mkdocs_codeinclude_plugin

--- a/src/get-started/HelloWorld.java
+++ b/src/get-started/HelloWorld.java
@@ -1,0 +1,7 @@
+
+public final class Run {
+
+  public static void main(String[] args) {
+    System.out.println("Hello, world!");
+  }
+}

--- a/src/get-started/HelloWorld.java
+++ b/src/get-started/HelloWorld.java
@@ -1,7 +1,0 @@
-
-public final class Run {
-
-  public static void main(String[] args) {
-    System.out.println("Hello, world!");
-  }
-}

--- a/src/get-started/java-binding.md
+++ b/src/get-started/java-binding.md
@@ -14,6 +14,12 @@ Exonum Java Binding provides:
   service development as a number of Java libraries.
 - Exonum Java Application — an Exonum node with built-in support
   for running Java services.
+  
+## Test Code Snippet
+
+<!--codeinclude-->
+[Hello World](./HelloWorld.java) block:main
+<!--/codeinclude-->
 
 ## Installation
 

--- a/src/get-started/java-binding.md
+++ b/src/get-started/java-binding.md
@@ -14,12 +14,6 @@ Exonum Java Binding provides:
   service development as a number of Java libraries.
 - Exonum Java Application — an Exonum node with built-in support
   for running Java services.
-  
-## Test Code Snippet
-
-<!--codeinclude-->
-[createBlockProof](../code-examples/java/exonum-java-binding/integration-tests/src/test/java/com/exonum/binding/test/BlockchainIntegrationTest.java) block:createBlockProof
-<!--/codeinclude-->
 
 ## Installation
 

--- a/src/get-started/java-binding.md
+++ b/src/get-started/java-binding.md
@@ -615,7 +615,7 @@ execution in the synchronous environment by offering simple network emulation
 
 For existing projects include the following dependency into your `pom.xml`:
 
-``` xml
+```xml
 <dependency>
   <groupId>com.exonum.binding</groupId>
   <artifactId>exonum-testkit</artifactId>
@@ -627,7 +627,7 @@ For existing projects include the following dependency into your `pom.xml`:
 As the TestKit uses a library with the implementation of native methods,
 pass `java.library.path` system property to JVM:
 
-``` none
+```none
 -Djava.library.path=$EXONUM_JAVA/lib/native
 ```
 

--- a/src/get-started/java-binding.md
+++ b/src/get-started/java-binding.md
@@ -18,7 +18,7 @@ Exonum Java Binding provides:
 ## Test Code Snippet
 
 <!--codeinclude-->
-[Hello World](./HelloWorld.java) block:main
+[createBlockProof](../code-examples/java/exonum-java-binding/integration-tests/src/test/java/com/exonum/binding/test/BlockchainIntegrationTest.java) block:createBlockProof
 <!--/codeinclude-->
 
 ## Installation

--- a/versioned.js
+++ b/versioned.js
@@ -35,12 +35,21 @@ const generateVersionedDocs = async (versions) => {
   const extraVersions = [...versions]
   extraVersions[0] = 'latest'
   for (let version of versions) {
+    // Update to the revision tagged with the `version` tag,
+    // and initialize the submodules.
     const [, error] = await to(git.checkout(version))
     if (error) {
       console.error(`Checkout failed. Tag ${version} is not built.`)
       failed++
       continue
     }
+    const [, updateError] = await to(git.updateSubmodules(true, true))
+    if (updateError) {
+      console.error(`Failed to update submodules. Tag ${version} is not built.`)
+      failed++
+      continue
+    }
+
     version = versions.indexOf(version) === 0 ? 'latest' : version
     const versionedMkdocs = YAML.load('mkdocs.yml')
     const configFile = `./version/${version}.yml`


### PR DESCRIPTION
### Overview

Adds a plugin to include Java code examples from source files.

Adds Exonum Java Binding as a Git submodule, to be able to include the code snippets from its source.

### Questions
1. Shall we use a git submodule or add a script syncing particular directories from EJB repository? Potentially, it will allow to reduce the paths lenghts, but will add 'accidental' changes to the diff (changes that have already been reviewed during the modifications in the main repository).

### See Also
- ECR-4250
- ECR-4132
- ECR-4258