### PR TITLE
Update java service dev docs for 0.10 [ECR-4241]

### DIFF
--- a/src/get-started/java-binding.md
+++ b/src/get-started/java-binding.md
@@ -142,6 +142,8 @@ abstract class [`AbstractService`][abstract-service].
 
 ### Schema Description
 
+<!-- todo: Rewrite the section — it lacks some structure -->
+
 Exonum provides several collection types to persist service data. The main
 types are sets, lists and maps. Data organization inside the
 collections is arranged in two ways – ordinary collections 
@@ -227,6 +229,23 @@ section of MerkleDB documentation for details.
       }
     }
     ```
+
+#### Blockchain Data
+
+[`BlockchainData`][blockchain-data] is the object providing access to blockchain data
+of a particular service instance.
+ 
+The service instance data is accessible via a `Prefixed` access which isolates
+the service data from all the other instances.
+ 
+On top of that, this class provides read-only access to persistent data of:
+ 
+- [Exonum Core][blockchain], containing information on blocks, transactions, 
+  execution results, consensus configuration, etc. 
+- Dispatcher Service, containing information on active service instances.
+- Other services.
+
+[blockchain-data]: file:///Users/user/Documents/exonum-java-binding/exonum-java-binding/target/site/apidocs/com/exonum/binding/core/blockchain/BlockchainData.html
 
 #### Serialization
 
@@ -480,36 +499,6 @@ must pay attention to **not** perform any blocking operations such as
 synchronous I/O in this handler, as it is invoked synchronously in the same
 thread that handles transactions. Blocking that thread will delay transaction
 processing on the node.
-
-### Core Schema API
-
-Users can access information stored in the blockchain by the framework using
-methods of [`Blockchain`][blockchain] class. This API can be used both in
-transaction code and in read requests. The following functionality is
-available:
-
-- `getHeight: long`
-  The height of the latest committed block in the blockchain
-- `getBlockHashes: ListIndex<HashCode>`
-  The list of all block hashes, indexed by the block height
-- `getBlockTransactions: ProofListIndexProxy<HashCode>`
-  The proof list of transaction hashes committed in the block with the given
-  height or ID
-- `getTxMessages: MapIndex<HashCode, TransactionMessage>`
-  The map of transaction messages identified by their SHA-256 hashes. Both
-  committed and in-pool (not yet processed) transactions are returned
-- `getTxResults: ProofMapIndexProxy<HashCode, ExecutionStatus>`
-  The map of transaction execution results identified by the corresponding
-  transaction SHA-256 hashes
-- `getTxLocations: MapIndex<HashCode, TransactionLocation>`
-  The map of transaction positions inside the blockchain identified by
-  the corresponding transaction SHA-256 hashes
-- `getBlocks: MapIndex<HashCode, Block>`
-  The map of block objects identified by the corresponding block hashes
-- `getLastBlock: Block`
-  The latest committed block
-- `getConsensusConfiguration: Config`
-  The consensus configuration for the latest height of the blockchain.
 
 ### External Service API
 

--- a/src/get-started/java-binding.md
+++ b/src/get-started/java-binding.md
@@ -321,7 +321,7 @@ A service schema object can be used to access data collections of this service.
     public final class FooService extends AbstractService {
 
       /** A numeric identifier of the "put" transaction. */
-      public static final int PUT_TX_ID = 0;
+      private static final int PUT_TX_ID = 0;
 
       @Inject
       public FooService(ServiceInstanceSpec instanceSpec) {

--- a/src/get-started/java-binding.md
+++ b/src/get-started/java-binding.md
@@ -410,7 +410,7 @@ Services can receive notifications:
   has been committed.
 
 Such notification allow inspecting the changes made by the transactions
-and modifying any service state.
+and modifying the service state.
 
 Exonum delivers these notification to implementations
 of [`Service#beforeTransactions`][service-before-transactions] and

--- a/src/get-started/java-binding.md
+++ b/src/get-started/java-binding.md
@@ -419,7 +419,7 @@ of [`Service#beforeTransactions`][service-before-transactions] and
 The `beforeTransactions` method sees the state of the database
 as of the last committed block, possibly, modified by the previously
 invoked `beforeTransactions` handlers of other services.
-The `afterTransactions` handlers see the blockchain state after all transactions 
+The `afterTransactions` handlers see the blockchain state after all transactions
 in the block have been applied.
 
 Both methods may make any changes to the service state, which will be included

--- a/src/get-started/java-binding.md
+++ b/src/get-started/java-binding.md
@@ -1493,12 +1493,6 @@ For using the library just include the dependency in your `pom.xml`:
 
 ## Known Limitations
 
-- Core collections necessary to form a complete cryptographic proof for user
-  service data (collections and their elements) are available only in a "raw"
-  form – without deserialization of the content, which makes their use somewhat
-  difficult.
-- Exonum Java App supports only the `simple` mode of the
-  [Supervisor service][supervisor-service].
 - Custom Rust services can be added to the application only by modifying and
   rebuilding thereof.
 - Exonum Java application does not support Windows yet.

--- a/src/get-started/java-binding.md
+++ b/src/get-started/java-binding.md
@@ -142,7 +142,7 @@ abstract class [`AbstractService`][abstract-service].
 
 ### Schema Description
 
-<!-- todo: Rewrite the section — it lacks some structure -->
+<!-- todo: Rewrite the section — it lacks some structure: ECR-4262 -->
 
 Exonum provides several collection types to persist service data. The main
 types are sets, lists and maps. Data organization inside the
@@ -188,8 +188,8 @@ See [Serialization](#serialization) for details.
     ```
 
 A set of named collections constitute a *service schema*. A service schema
-may be created using a `Prefixed` database access object, which provides
-isolation of all service indexes from other instances.
+is usually created using a [`Prefixed`](#blockchain-data) database access
+object, which provides isolation of all service indexes from other instances.
 
 For convenient access to service collections you can implement a factory
 of service collections.
@@ -197,7 +197,7 @@ of service collections.
 *The state of the service in the blockchain* is determined by the index hashes
 of its Merkelized collections. Exonum performs the _state aggregation_
 of all non-grouped Merkelized collections automatically. See
-the ["State Aggregation"](../architecture/merkledb.md#state-aggregation)
+the [“State Aggregation”](../architecture/merkledb.md#state-aggregation)
 section of MerkleDB documentation for details.
 
 !!! note "Example of a Service Schema with a single Merkelized collection"
@@ -374,7 +374,7 @@ that the client needs to distinguish:
 - Same sender and receiver.
 
 An exception of any other type will be recorded with _no_ error code
-as an "unexpected" execution error.
+as an “unexpected” execution error.
 
 If transaction execution fails, the changes made by the transaction are
 rolled back, while the error data is [stored in the database][call-errors-registry]
@@ -460,7 +460,7 @@ the REST-interface of the service.
 [`Service#createPublicApiHandlers`][service-create-public-api] method is used to
 set the handlers for HTTP requests. These handlers are available at the
 common path corresponding to the service name. Thus, the `/balance/:walletId`
-handler for balance requests in the "cryptocurrency" service will be available
+handler for balance requests in the “cryptocurrency” service will be available
 at `/api/services/cryptocurrency/balance/:walletId`.
 
 See [documentation][vertx-web-docs] on the possibilities of `Vert.x` used as a web

--- a/src/get-started/java-binding.md
+++ b/src/get-started/java-binding.md
@@ -245,7 +245,7 @@ On top of that, this class provides read-only access to persistent data of:
 - Dispatcher Service, containing information on active service instances.
 - Other services.
 
-[blockchain-data]: file:///Users/user/Documents/exonum-java-binding/exonum-java-binding/target/site/apidocs/com/exonum/binding/core/blockchain/BlockchainData.html
+[blockchain-data]: https://exonum.com/doc/api/java-binding/0.10.0/com/exonum/binding/core/blockchain/BlockchainData.html
 
 #### Serialization
 
@@ -448,9 +448,8 @@ for further user reference. Light clients also provide access to information
 on the transaction execution result (which may be either success or failure)
 to their users.
 
-<!-- todo: Replace everywhere 'file:///Users/user/Documents/exonum-java-binding/exonum-java-binding/target/site/apidocs/' with appropr. base URL -->
-[execution-exception]: file:///Users/user/Documents/exonum-java-binding/exonum-java-binding/target/site/apidocs/com/exonum/binding/core/transaction/ExecutionException.html
-[call-errors-registry]: file:///Users/user/Documents/exonum-java-binding/exonum-java-binding/target/site/apidocs/com/exonum/binding/core/blockchain/Blockchain.html#getCallErrors(long)
+[execution-exception]: https://exonum.com/doc/api/java-binding/0.10.0/com/exonum/binding/core/transaction/ExecutionException.html
+[call-errors-registry]: https://exonum.com/doc/api/java-binding/0.10.0/com/exonum/binding/core/blockchain/Blockchain.html#getCallErrors(long)
 
 #### Before and After Transactions Handlers
 
@@ -1522,8 +1521,8 @@ For using the library just include the dependency in your `pom.xml`:
 [schema]: https://exonum.com/doc/api/java-binding/0.9.0-rc2/com/exonum/binding/core/service/Schema.html
 [service]: https://exonum.com/doc/api/java-binding/0.9.0-rc2/com/exonum/binding/core/service/Service.html
 [service-after-commit]: https://exonum.com/doc/api/java-binding/0.9.0-rc2/com/exonum/binding/core/service/Service.html#afterCommit(com.exonum.binding.service.BlockCommittedEvent)
-[service-before-transactions]: file:///Users/user/Documents/exonum-java-binding/exonum-java-binding/target/site/apidocs/com/exonum/binding/core/service/Service.html#beforeTransactions(com.exonum.binding.core.blockchain.BlockchainData)
-[service-after-transactions]: file:///Users/user/Documents/exonum-java-binding/exonum-java-binding/target/site/apidocs/com/exonum/binding/core/service/Service.html#afterTransactions(com.exonum.binding.core.blockchain.BlockchainData)
+[service-before-transactions]: https://exonum.com/doc/api/java-binding/0.10.0/com/exonum/binding/core/service/Service.html#beforeTransactions(com.exonum.binding.core.blockchain.BlockchainData)
+[service-after-transactions]: https://exonum.com/doc/api/java-binding/0.10.0/com/exonum/binding/core/service/Service.html#afterTransactions(com.exonum.binding.core.blockchain.BlockchainData)
 [node-submit-transaction]: https://exonum.com/doc/api/java-binding/0.9.0-rc2/com/exonum/binding/core/service/Node.html#submitTransaction(com.exonum.binding.transaction.RawTransaction)
 [slf4j-home]: https://www.slf4j.org/
 [standard-serializers]: https://exonum.com/doc/api/java-binding/0.9.0-rc2/com/exonum/binding/common/serialization/StandardSerializers.html

--- a/src/get-started/java-binding.md
+++ b/src/get-started/java-binding.md
@@ -406,7 +406,7 @@ Services can receive notifications:
 
 - before any transactions in a block has been processed
 - after all transactions in a block has been processed, but before the block 
-has been committed.
+  has been committed.
 
 Such notification allow inspecting the changes made by the transactions 
 and modifying any service state.

--- a/src/get-started/java-binding.md
+++ b/src/get-started/java-binding.md
@@ -136,7 +136,7 @@ software model of services in the [corresponding section][Exonum-services].
 
 In Java, the abstraction of a service is represented by
 [`Service`][service] interface. Implementations can use the
-abstract class [`AbstractService`][abstractservice].
+abstract class [`AbstractService`][abstract-service].
 
 <!-- todo: Add an example of a bare-bones Service -->
 
@@ -233,12 +233,12 @@ section of MerkleDB documentation for details.
 As Exonum storage accepts data in the form of byte arrays,
 storing user data requires serialization.
 Java Binding provides a set of built-in *serializers* that you can find
-in the [`StandardSerializers`][standardserializers] utility class.
+in the [`StandardSerializers`][standard-serializers] utility class.
 The list of serializers covers the most often-used entities and includes:
 
 - Standard types: `boolean`, `float`, `double`, `byte[]` and `String`.
   Integers with various encoding types,
-  see [`StandardSerializers`][standardserializers] Java documentation
+  see [`StandardSerializers`][standard-serializers] Java documentation
   and the table below.
 - Exonum types: `PrivateKey`, `PublicKey` and `HashCode`.
 - Any Protobuf messages using `StandardSerializers#protobuf`.
@@ -1519,7 +1519,7 @@ For using the library just include the dependency in your `pom.xml`:
 - [Javadocs](https://exonum.com/doc/api/java-binding/0.9.0-rc2/index.html)
 - [Rust instruction](create-service.md)
 
-[abstractservice]: https://exonum.com/doc/api/java-binding/0.9.0-rc2/com/exonum/binding/core/service/AbstractService.html
+[abstract-service]: https://exonum.com/doc/api/java-binding/0.9.0-rc2/com/exonum/binding/core/service/AbstractService.html
 [blockchain]: https://exonum.com/doc/api/java-binding/0.9.0-rc2/com/exonum/binding/core/blockchain/Blockchain.html
 [brew-install]: https://docs.brew.sh/Installation
 [build-description]: https://github.com/exonum/exonum-java-binding/blob/ejb/v0.9.0-rc2/exonum-java-binding/service-archetype/src/main/resources/archetype-resources/pom.xml
@@ -1535,7 +1535,6 @@ For using the library just include the dependency in your `pom.xml`:
 [libsodium]: https://download.libsodium.org/doc/
 [log4j-docs]: https://logging.apache.org/log4j/2.x/manual/index.html
 [log4j-home]: https://logging.apache.org/log4j
-[nodefake]: https://exonum.com/doc/api/java-binding/0.9.0-rc2/com/exonum/binding/core/service/NodeFake.html
 [schema]: https://exonum.com/doc/api/java-binding/0.9.0-rc2/com/exonum/binding/core/service/Schema.html
 [service]: https://exonum.com/doc/api/java-binding/0.9.0-rc2/com/exonum/binding/core/service/Service.html
 [service-after-commit]: https://exonum.com/doc/api/java-binding/0.9.0-rc2/com/exonum/binding/core/service/Service.html#afterCommit(com.exonum.binding.service.BlockCommittedEvent)
@@ -1543,7 +1542,7 @@ For using the library just include the dependency in your `pom.xml`:
 [service-after-transactions]: file:///Users/user/Documents/exonum-java-binding/exonum-java-binding/target/site/apidocs/com/exonum/binding/core/service/Service.html#afterTransactions(com.exonum.binding.core.blockchain.BlockchainData)
 [node-submit-transaction]: https://exonum.com/doc/api/java-binding/0.9.0-rc2/com/exonum/binding/core/service/Node.html#submitTransaction(com.exonum.binding.transaction.RawTransaction)
 [slf4j-home]: https://www.slf4j.org/
-[standardserializers]: https://exonum.com/doc/api/java-binding/0.9.0-rc2/com/exonum/binding/common/serialization/StandardSerializers.html
+[standard-serializers]: https://exonum.com/doc/api/java-binding/0.9.0-rc2/com/exonum/binding/common/serialization/StandardSerializers.html
 [standard-supervisor-rustdoc]: https://docs.rs/exonum-supervisor/0.13.0-rc.2/exonum_supervisor/
 [storage-indices]: https://exonum.com/doc/api/java-binding/0.9.0-rc2/com/exonum/binding/core/storage/indices/package-summary.html
 <!-- TODO: link to the documentation page for supervisor -->

--- a/src/get-started/java-binding.md
+++ b/src/get-started/java-binding.md
@@ -641,7 +641,7 @@ execution in the synchronous environment by offering simple network emulation
 !!! note "New projects"
     `exonum-testkit` is already included in projects generated with
     [`exonum-java-binding-service-archetype`](#creating-project) and you can
-    skip the following instructions:
+    skip the following instructions.
 
 For existing projects include the following dependency into your `pom.xml`:
 
@@ -658,11 +658,11 @@ As the TestKit uses a library with the implementation of native methods,
 pass `java.library.path` system property to JVM:
 
 ``` none
--Djava.library.path=$EXONUM_JAVA/lib/native
+-Djava.library.path="${EXONUM_HOME}/lib/native"
 ```
 
-`$EXONUM_JAVA` environment variable should point at installation location,
-as specified in [How to Run a Service section](#how-to-run-a-service).
+`EXONUM_HOME` environment variable should point at installation location,
+as specified in [<<After Install>>](#after-install) section.
 
 Packaged artifact should be available for integration tests that use TestKit,
 so `Failsafe` for Maven should be configured as follows:
@@ -673,7 +673,7 @@ so `Failsafe` for Maven should be configured as follows:
     <artifactId>maven-failsafe-plugin</artifactId>
     <configuration>
         <argLine>
-            -Djava.library.path=${path-to-java-bindings-library}
+            -Djava.library.path=${env.EXONUM_HOME}/lib/native
         </argLine>
     </configuration>
     <executions>

--- a/src/get-started/java-binding.md
+++ b/src/get-started/java-binding.md
@@ -425,7 +425,7 @@ the same observable result on all nodes of the system.
 If exceptions occur in this handler, Exonum will roll back any changes made
 to the persistent storage in it.
 
-The execution result of `before-`/`afterTransactions` is also saved in 
+The execution result of `before-` / `afterTransactions` is also saved in 
 the [database][call-errors-registry].
 
 ### Blockchain Events

--- a/src/get-started/java-binding.md
+++ b/src/get-started/java-binding.md
@@ -146,8 +146,8 @@ abstract class [`AbstractService`][abstract-service].
 
 Exonum provides several collection types to persist service data. The main
 types are sets, lists and maps. Data organization inside the
-collections is arranged in two ways – ordinary collections 
-and Merkelized collections; the latter allow providing cryptographic evidence 
+collections is arranged in two ways – ordinary collections
+and Merkelized collections; the latter allow providing cryptographic evidence
 of the authenticity of data to the clients of
 the system (for example, that an element is stored in the collection under a
 certain key). The [blockchain state](../glossary.md#blockchain-state) is
@@ -195,8 +195,8 @@ For convenient access to service collections you can implement a factory
 of service collections.
 
 *The state of the service in the blockchain* is determined by the index hashes
-of its Merkelized collections. Exonum performs the _state aggregation_ 
-of all non-grouped Merkelized collections automatically. See 
+of its Merkelized collections. Exonum performs the _state aggregation_
+of all non-grouped Merkelized collections automatically. See
 the ["State Aggregation"](../architecture/merkledb.md#state-aggregation)
 section of MerkleDB documentation for details.
 
@@ -233,14 +233,14 @@ section of MerkleDB documentation for details.
 
 [`BlockchainData`][blockchain-data] is the object providing access to blockchain
 data of a particular service instance.
- 
+
 The service instance data is accessible via a `Prefixed` access which isolates
 the service data from all the other instances.
- 
+
 On top of that, this class provides read-only access to persistent data of:
- 
-- [Exonum Core][blockchain], containing information on blocks, transactions, 
-  execution results, consensus configuration, etc. 
+
+- [Exonum Core][blockchain], containing information on blocks, transactions,
+  execution results, consensus configuration, etc.
 - Dispatcher, containing information on active service instances.
 - Other services.
 
@@ -295,7 +295,7 @@ rules – see the corresponding section of our [documentation][transactions].
 A transaction is a `Service` method that is annotated with
 the [`@Transaction`][transaction] annotation and defines the transaction
 business logic. The transaction method describes the operations that are applied
-to the current storage state when the transaction is executed. 
+to the current storage state when the transaction is executed.
 
 A transaction method must accept two parameters:
 
@@ -303,7 +303,7 @@ A transaction method must accept two parameters:
   Protobuf messages are deserialized using a `#parseFrom(byte[])` method of
   the actual parameter type.
 2. _execution context_ as `TransactionContext`.
-  
+
 The [execution context][transaction-execution-context] provides:
 
 - A mutable access to the blockchain data, which allows performing modifying
@@ -318,15 +318,15 @@ A service schema object can be used to access data collections of this service.
 
     ```java
     public final class FooService extends AbstractService {
-      
+
       /** A numeric identifier of the "put" transaction. */
       public static final int PUT_TX_ID = 0;
-    
+
       @Inject
       public FooService(ServiceInstanceSpec instanceSpec) {
         super(instanceSpec);
       }
-      
+
       /**
        * Puts an entry (a key-value pair) into the test proof map.
        *
@@ -342,7 +342,7 @@ A service schema object can be used to access data collections of this service.
         schema.testMap()
             .put(key, value);
       }
-      
+
       @Override
       public void createPublicApiHandlers(Node node, Router router) {
         // No handlers
@@ -358,7 +358,7 @@ state hash, or an execution exception.
 
 ##### Exceptions
 
-Transaction methods may throw [`ExecutionException`][execution-exception] 
+Transaction methods may throw [`ExecutionException`][execution-exception]
 to notify Exonum about an error in a transaction execution.
 
 The `ExecutionException` contains an integer error code and
@@ -405,15 +405,15 @@ in the network.
 Services can receive notifications:
 
 - before any transactions in a block has been processed
-- after all transactions in a block has been processed, but before the block 
+- after all transactions in a block has been processed, but before the block
   has been committed.
 
-Such notification allow inspecting the changes made by the transactions 
+Such notification allow inspecting the changes made by the transactions
 and modifying any service state.
 
 Exonum delivers these notification to implementations
-of [`Service#beforeTransactions`][service-before-transactions] and 
-[`Service#afterTransactions`][service-after-transactions] methods. 
+of [`Service#beforeTransactions`][service-before-transactions] and
+[`Service#afterTransactions`][service-after-transactions] methods.
 The `beforeTransactions` method sees the state of the database
 as of the last committed block, possibly, modified by the previously
 invoked `beforeTransactions` handlers of other services.
@@ -425,7 +425,7 @@ the same observable result on all nodes of the system.
 If exceptions occur in this handler, Exonum will roll back any changes made
 to the persistent storage in it.
 
-The execution result of `before-` / `afterTransactions` is also saved in 
+The execution result of `before-` / `afterTransactions` is also saved in
 the [database][call-errors-registry].
 
 ### Blockchain Events
@@ -504,8 +504,8 @@ in transactions and/or read requests.
 <!-- TODO: link the complete documentation on reconfiguration,
 especially in terms of its invocation by administrators -->
 
-[Exonum supervisor service](../advanced/supervisor.md) 
-provides a mechanism to reconfigure the started service instances. 
+[Exonum supervisor service](../advanced/supervisor.md)
+provides a mechanism to reconfigure the started service instances.
 The re-configuration protocol for _services_
 is similar to the one for consensus configuration.
 This protocol includes the following steps:

--- a/src/get-started/java-binding.md
+++ b/src/get-started/java-binding.md
@@ -537,7 +537,8 @@ Exonum invokes this method when a new service instance is added
 to the blockchain. Administrators, initiating this action,
 may pass some initialization parameters. A service is responsible for
 validation of these parameters. If they are incorrect, it shall throw
-an Exception, which will abort the start of this service instance.
+an [`ExecutionException`][execution-exception], which will abort the start
+of this service instance.
 
 A service shall also update its _persistent_ state based on these parameters.
 It shall not derive the `Service` _object_ state from them, as
@@ -545,8 +546,8 @@ Exonum may instantiate multiple `Service` objects for a single
 service instance (e.g., when a node is stopped and then restarted).
 
 For example, a service may set some initial values in its collections,
-or save all or some configuration parameters as is for later retrieval in transactions
-and/or read requests.
+or save all or some configuration parameters as is for later retrieval
+in transactions and/or read requests.
 
 <!-- TODO: example -->
 
@@ -555,8 +556,9 @@ and/or read requests.
 <!-- TODO: link the complete documentation on reconfiguration,
 especially in terms of its invocation by administrators -->
 
-Exonum supervisor service provides a mechanism to reconfigure
-the started service instances. The re-configuration protocol for _services_
+[Exonum supervisor service](../advanced/supervisor.md) 
+provides a mechanism to reconfigure the started service instances. 
+The re-configuration protocol for _services_
 is similar to the one for consensus configuration.
 This protocol includes the following steps:
 
@@ -575,7 +577,8 @@ implementing [`Configurable`][configurable] interface.
 Exonum includes a [standard implementation][standard-supervisor-rustdoc]
 of the supervisor service.
 See its documentation to learn how to invoke the re-configuration process
-of a started service instance.
+of a started service instance. Also, consider using the standard client
+application — [`exonum-launcher`][exonum-launcher].
 
 A service that does not need the same protocol for its reconfiguration as
 for consensus reconfiguration may implement it itself as a set of transactions.

--- a/src/get-started/java-binding.md
+++ b/src/get-started/java-binding.md
@@ -469,7 +469,7 @@ framework.
 !!! note
     Java services use a _separate_ server from Rust services.
     The TCP ports of Java and Rust servers are specified
-    when a node is started, see [«Running the node»](#running-the-node)
+    when a node is started, see [“Running the node”](#running-the-node)
     section for details.
 
 ### Configuration
@@ -599,7 +599,7 @@ pass `java.library.path` system property to JVM:
 ```
 
 `EXONUM_HOME` environment variable should point at the installation location,
-as specified in [«After Install»](#after-install) section.
+as specified in [“After Install”](#after-install) section.
 
 Packaged artifact should be available for integration tests that use TestKit,
 so Maven Failsafe Plugin should be configured as follows:

--- a/src/get-started/java-binding.md
+++ b/src/get-started/java-binding.md
@@ -650,11 +650,11 @@ pass `java.library.path` system property to JVM:
 -Djava.library.path="${EXONUM_HOME}/lib/native"
 ```
 
-`EXONUM_HOME` environment variable should point at installation location,
-as specified in [<<After Install>>](#after-install) section.
+`EXONUM_HOME` environment variable should point at the installation location,
+as specified in [«After Install»](#after-install) section.
 
 Packaged artifact should be available for integration tests that use TestKit,
-so `Failsafe` for Maven should be configured as follows:
+so Maven Failsafe Plugin should be configured as follows:
 
 ```xml
 <plugin>
@@ -709,7 +709,8 @@ node, a single service with no configuration and without Time Oracle. To
 instantiate the TestKit do the following:
 
 ```java
-ServiceArtifactId artifactId = ServiceArtifactId.newJavaId("com.exonum.binding:test-service:1.0.0");
+ServiceArtifactId artifactId = ServiceArtifactId
+    .newJavaId("com.exonum.binding/test-service", "1.0.0");
 String artifactFilename = "test-service.jar";
 String serviceName = "test-service";
 int serviceId = 46;

--- a/src/get-started/java-binding.md
+++ b/src/get-started/java-binding.md
@@ -599,6 +599,7 @@ A service module shall:
 
 !!! note "Minimalistic Example of Service Module"
     ```java
+
     @Extension
     public class ServiceModule extends AbstractServiceModule {
 
@@ -606,10 +607,6 @@ A service module shall:
       protected void configure() {
         // Define the Service implementation.
         bind(Service.class).to(CryptocurrencyService.class).in(Singleton.class);
-
-        // Define the TransactionConverter implementation required
-        // by the CryptocurrencyService.
-        bind(TransactionConverter.class).to(CryptocurrencyTransactionConverter.class);
       }
     }
     ```
@@ -1544,7 +1541,6 @@ For using the library just include the dependency in your `pom.xml`:
 [transaction-execution-context]: https://exonum.com/doc/api/java-binding/0.9.0-rc2/com/exonum/binding/core/transaction/TransactionContext.html
 [transactions]: ../architecture/transactions.md
 [transactions-messages]: ../architecture/transactions.md#messages
-[transactionconvererter]: https://exonum.com/doc/api/java-binding/0.9.0-rc2/com/exonum/binding/core/service/TransactionConverter.html
 [vertx-web-docs]: https://vertx.io/docs/vertx-web/java/#_basic_vert_x_web_concepts
 [maven-install]: https://maven.apache.org/install.html
 [cryptofunctions-ed25519]: https://exonum.com/doc/api/java-binding/0.9.0-rc2/com/exonum/binding/common/crypto/CryptoFunctions.html#ed25519--

--- a/src/get-started/java-binding.md
+++ b/src/get-started/java-binding.md
@@ -418,7 +418,8 @@ of [`Service#beforeTransactions`][service-before-transactions] and
 The `beforeTransactions` method sees the state of the database
 as of the last committed block, possibly, modified by the previously
 invoked `beforeTransactions` handlers of other services.
-The `afterTransactions` handlers — after all transactions have been applied.
+The `afterTransactions` handlers see the blockchain state after all transactions 
+in the block have been applied.
 
 Both methods may make any changes to the service state, which will be included
 in the block. As transactions, the implementations must produce

--- a/src/get-started/java-binding.md
+++ b/src/get-started/java-binding.md
@@ -1,6 +1,6 @@
 # Java Binding User Guide
 
-<!-- cspell:ignore testnet,prepend,JDWP -->
+<!-- cspell:ignore testnet,prepend,JDWP,Protoc -->
 
 **Exonum Java Binding** is a framework for building blockchain applications in
 Java, powered by Exonum.
@@ -231,8 +231,8 @@ section of MerkleDB documentation for details.
 
 #### Blockchain Data
 
-[`BlockchainData`][blockchain-data] is the object providing access to blockchain data
-of a particular service instance.
+[`BlockchainData`][blockchain-data] is the object providing access to blockchain
+data of a particular service instance.
  
 The service instance data is accessible via a `Prefixed` access which isolates
 the service data from all the other instances.

--- a/src/get-started/java-binding.md
+++ b/src/get-started/java-binding.md
@@ -171,7 +171,6 @@ database view is provided by the framework: `Snapshot` can be
 requested at any time, while `Fork` – only when the transaction is executed. The
 lifetime of these objects is limited by the scope of the method to which they
 are passed to.
-<!-- todo: Do we need to describe the Prefixed etc? -->
 
 Exonum stores elements in collections as byte arrays. Therefore,
 serializers for values stored in collections must be provided.
@@ -242,7 +241,7 @@ On top of that, this class provides read-only access to persistent data of:
  
 - [Exonum Core][blockchain], containing information on blocks, transactions, 
   execution results, consensus configuration, etc. 
-- Dispatcher Service, containing information on active service instances.
+- Dispatcher, containing information on active service instances.
 - Other services.
 
 [blockchain-data]: https://exonum.com/doc/api/java-binding/0.10.0/com/exonum/binding/core/blockchain/BlockchainData.html

--- a/src/get-started/java-binding.md
+++ b/src/get-started/java-binding.md
@@ -241,7 +241,8 @@ On top of that, this class provides read-only access to persistent data of:
 
 - [Exonum Core][blockchain], containing information on blocks, transactions,
   execution results, consensus configuration, etc.
-- Dispatcher, containing information on active service instances.
+- Dispatcher, containing information on deployed service artifacts and active
+  service instances.
 - Other services.
 
 [blockchain-data]: https://exonum.com/doc/api/java-binding/0.10.0/com/exonum/binding/core/blockchain/BlockchainData.html


### PR DESCRIPTION
Update the documentation on service development (no testing — see ECR-4256).

There are a couple of questions (@slowli ) marked with todo comments.

Some high-level questions/considerations:
- I am not quite happy with the section on schema definition — it lacks some structure.
- Shall we keep the sections on transaction messages and lifecycle for integrity, or just link the main sections?

Might be more convenient to review commit-by-commit.