### PR TITLE
Use a separate tag for tutorial code:

### DIFF
--- a/src/get-started/first-java-service.md
+++ b/src/get-started/first-java-service.md
@@ -11,7 +11,7 @@ but gives a solid foundation to learn about that in subsequent materials.
 
 The full tutorial code is available in our [Git repository][car-registry-git].
 
-[car-registry-git]: https://github.com/exonum/exonum-java-binding/tree/ejb/v0.10.0/exonum-java-binding/tutorials/car-registry
+[car-registry-git]: https://github.com/exonum/exonum-java-binding/tree/tutorial/v0.10.0/exonum-java-binding/tutorials/car-registry
 
 ## Prerequisites
 


### PR DESCRIPTION
As tutorial code depends on both EJB and JLC (which,
in turn, depends on EJB messages and common library),
it cannot always be completed when _just_ EJB is released —
it may need a compatible JLC release also (if the previous
does not work with the new EJB). Hence, it have to
use a separate Git tag, that is set when both EJB and JLC
are released.

See the entries in the release procedure for details:
https://wiki.bf.local/display/EJB/Java+Binding+Release+Checklist+Template
