### PR TITLE
Use PyPI published mkdocs-codeinclude-plugin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ Jinja2~=2.11
 Pygments~=2.5
 pygments-github-lexers~=0.0.5
 
--e git+https://github.com/exonum/mkdocs-codeinclude-plugin@cf40bdcfeb11600e1e571b69fe2abae80173971c#egg=mkdocs_codeinclude_plugin
+mkdocs_codeinclude_plugin=0.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ Jinja2~=2.11
 Pygments~=2.5
 pygments-github-lexers~=0.0.5
 
-mkdocs_codeinclude_plugin=0.0.1
+mkdocs_codeinclude_plugin==0.0.1


### PR DESCRIPTION
This library has sat unpublished for too long, but I've now _finally_ published it to PyPI 😅 

Please migrate to the published version ASAP, so that you can control exposure to new updates as I merge them over on the main git repository.

<!--
Please target the following branch:
- `master` if your pull request fixes bugs in the documentation, describes
  released features, etc. In other words,
  a pull request targeting `master` should be possible to merge and
  push to https://exonum.com/doc/ at any time.
- `develop` if your pull request describes features introduced into an upcoming
  version of Exonum. A request targeting `develop` should be pushed to
  https://exonum.com/doc/ no earlier than this upcoming version is released.
  If your documentation update has its own feature-branch,
  e.g., `develop-ejb-1.1`, please target that one.
-->
